### PR TITLE
acu126131 Make attributor rconfy

### DIFF
--- a/attributor.rconf
+++ b/attributor.rconf
@@ -1,0 +1,9 @@
+ruby do
+  version  'ruby-1.9.3-p448'
+  rubygems '1.8.24'
+end
+bundler do
+  version     '1.2.5'
+  exclusions  'deployment'
+  bundle_path File.join(ENV["HOME"], '.rightscale_bundle', 'attributor')
+end


### PR DESCRIPTION
Now you can set up it's ruby version (rbenv) and Bundle by typing 'rconf' in the project root.
