### PR TITLE
Describing Attribute example option

### DIFF
--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -57,6 +57,10 @@ module Attributor
 
     def describe(shallow=true)
       description = self.options.clone
+      # Make sure this option definition is not mistaken for the real generated example
+      if ( ex_def = description.delete(:example) )
+        description[:example_definition] = ex_def
+      end
 
       if (reference = description.delete :reference)
         description[:reference] = reference.name

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -44,6 +44,15 @@ describe Attributor::Attribute do
 
     
     its(:describe) { should == expected }
+    
+    context 'with example options' do
+      let(:attribute_options) { {:description=> "something", :example => "ex_def"} }
+      its(:describe) { should have_key(:example_definition) }
+      its(:describe) { should_not have_key(:example) }
+      it 'should have the example value in the :example_definition key' do
+        subject.describe[:example_definition].should == "ex_def"
+      end
+    end
 
     context 'for an anonymous type (aka: Struct)' do
       let(:attribute_options) { Hash.new }


### PR DESCRIPTION
describe the :example option as :example_definition to make sure it is ......not confused for a real generated example. Build missing describe spec.
