### PR TITLE
Support defining keys and/or value types for Hashes

### DIFF
--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -123,9 +123,8 @@ module Attributor
       # TODO: support more options like :max_size
       case name
       when :member_options
-
       else
-        :unknown
+        return :unknown
       end
 
       :ok

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -6,9 +6,78 @@ module Attributor
       return ::Hash
     end
 
-    def self.example(context=nil, options={})
-      ::Hash.new
+    # @example Collection.of(Integer)
+    #
+    def self.of( key: Object, value: Object )
+      if key
+        resolved_key_type = Attributor.resolve_type(key)
+        unless resolved_key_type.ancestors.include?(Attributor::Type)
+          raise Attributor::AttributorException.new("Hashes only support key types that are Attributor::Types. Got #{resolved_key_type.name}")
+        end
+      end
+
+      if value
+        resolved_value_type = Attributor.resolve_type(value)
+        unless resolved_value_type.ancestors.include?(Attributor::Type)
+          raise Attributor::AttributorException.new("Hashes only support value types that are Attributor::Types. Got #{resolved_value_type.name}")
+        end
+      end
+      
+      Class.new(self) do
+        @key_type = resolved_key_type
+        @value_type = resolved_value_type
+      end
+    end
+    
+    def self.key_type
+      @key_type 
     end
 
+    def self.value_type
+      @value_type 
+    end
+        
+    def self.example(context=nil, options={})
+      result = ::Hash.new
+      # Let's not bother to generate any hash contents if there's absolutely no type defined
+      return result unless key_type || value_type
+      
+      size = rand(3) + 1
+
+      size.times do |i|
+        subcontext = "#{context}[#{i}]"
+        result[key_type.example(subcontext)] = value_type.example(subcontext)
+      end
+
+      result
+    end
+
+    def self.check_option!(name, definition)
+      case name
+      when :key_type
+      when :value_type  
+      else
+        return :unknown
+      end
+      :ok
+    end
+    
+    def self.load(value)
+      if value.nil?
+        return nil
+      elsif value.is_a?(::Hash)
+        loaded_value = value
+      elsif value.is_a?(::String)
+        loaded_value = decode_json(value)
+      else
+        raise AttributorException.new("Do not know how to decode a Hash from a #{value.class.name}")
+      end
+
+      return loaded_value unless key_type || value_type
+      
+      loaded_value.each_with_object({}) do| (k, v), obj |
+        obj[self.key_type.load(k)] = self.value_type.load(v)
+      end
+    end
   end
 end

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -12,19 +12,85 @@ describe Attributor::Hash do
   end
 
   context '.example' do
-    it 'should return an empty Hash' do
-      type.example.should eq(Hash.new)
+    context 'for a simple hash' do
+      it 'should return an empty Hash' do
+        type.example.should eq(Hash.new)
+      end
+    end
+    
+    context 'for a typed hash' do
+      subject(:example){ Attributor::Hash.of( value: Integer).example}
+      it 'should return a hash with keys and/or values of the right type' do
+        example.should be_kind_of(::Hash)
+        example.keys.size.should > 0
+        example.values.all?{|v| v.kind_of? Integer}.should be(true)
+      end
     end
   end
 
   context '.load' do
     let(:value) { {one: 'two', three: 4} }
 
-    context 'for a hash' do
-
+    context 'for a simple hash' do
       it 'returns the hash' do
         type.load(value).should be(value)
       end
+    end
+    
+    context 'for a typed hash' do
+      subject(:type){ Attributor::Hash.of(key: String, value: Integer)}
+      context 'with good values' do
+        let(:value) { {one: '1', 'three' => 3} }
+        it 'should coerce good values into the correct types' do
+          type.load(value).should == {'one' => 1, 'three' => 3}
+        end 
+      end
+
+      context 'with incompatible values' do
+        let(:value) { {one: 'two', three: 4} }
+        it 'should fail' do
+          expect{
+            type.load(value)
+          }.to raise_error(/invalid value for Integer/)
+        end
+      end
+    end
+    
+    context 'for a partially typed hash' do
+      subject(:type){ Attributor::Hash.of( value: Integer) }
+      context 'with good values' do
+        let(:value) { {one: '1', [1,2,3] => 3} }
+        it 'should coerce only values into the correct types (and leave keys alone)' do
+          type.load(value).should == {:one => 1,  [1,2,3] => 3 }
+        end 
+      end
+    end
+  end
+  
+  context '.of' do
+    let(:key_type){ String }
+    let(:value_type){ Integer }
+
+    context 'specific key and value types' do
+      it 'saves the passed values to the created class' do      
+        klass = type.of(key: key_type, value: value_type)
+        klass.should be_a(::Class)
+        klass.ancestors.should include(Attributor::Hash) 
+        klass.key_type.should == Attributor::String
+        klass.value_type.should == Attributor::Integer
+      end
+    end
+  end
+  
+  context '.check_option!' do
+    it 'accepts key_type:' do
+      subject.check_option!(:key_type, String).should == :ok
+    end
+    it 'accepts value_type'  do
+      subject.check_option!(:value_type, Object).should == :ok
+    end
+    it 'rejects unknown options'  do
+      subject.check_option!(:bad_option, Object).should == :unknown
     end
 
   end
@@ -40,6 +106,7 @@ describe Attributor::Hash do
         attribute.example.should be(example_hash)
       end
     end
+    
   end
 end
 


### PR DESCRIPTION
Example:
Hash.of(key: String, value: Hash)
This will load/coerce values, as well as will support the appropriate typed examples for it.
