### PR TITLE
Improved context reporting in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ next
   * Ids type. A helper for creating CSVs with members matching a given a type's :identity option.
 * Allow instances of Models to be initialized with initial data. 
   * Supported formats for the data are equivalent to the loading formats (i.e. ruby Hash, a JSON string or another instance of the same model type).
-
+* Improved context reporting in errors
+  * Added contextual information while loading and dumping attributes.
+    * `load` takes a new `context` argument (defaulting to a system-wide root) in the form of an array of parent segments.
+    * `validate` takes a `context` argument that (instead of a string) is now an array of parent segments.
+    * `dump` takes a `context:` option parameter of the same type
+  * Enhanced error messages to report the correct context scope.
 
 
 2.0.0

--- a/lib/attributor.rb
+++ b/lib/attributor.rb
@@ -34,7 +34,8 @@ module Attributor
 
   # hierarchical separator string for composing human readable attributes
   SEPARATOR = '.'.freeze
-
+  DEFAULT_ROOT_CONTEXT = ['$'].freeze
+  
   # @param type [Class] The class of the type to resolve
   #
   def self.resolve_type(attr_type, options={}, constructor_block=nil)
@@ -57,7 +58,16 @@ module Attributor
     klass
   end
   
-
+  def self.humanize_context( context )
+    raise "NIL CONTEXT PASSED TO HUMANZE!!" unless context
+    raise "INVALID CONTEXT!!! (got: #{context.inspect})" unless context.is_a? Enumerable
+    begin
+      return context.join('.')
+    rescue Exception => e
+      raise "Error creating context string: #{e.message}"
+    end
+  end
+  
   MODULE_PREFIX       = "Attributor\:\:".freeze
   MODULE_PREFIX_REGEX = Regexp.new(MODULE_PREFIX)
 

--- a/lib/attributor/exceptions.rb
+++ b/lib/attributor/exceptions.rb
@@ -7,25 +7,32 @@ module Attributor
   
   class IncompatibleTypeError < LoadError
     
-    def initialize(type:, value_type:)
-      super "Type #{type} cannot load values of type #{value_type}"
+    def initialize(type:, value_type: , context: )
+      super "Type #{type} cannot load values of type #{value_type} while loading #{Attributor.humanize_context(context)}."
     end
   end
 
   class CoercionError < LoadError
-    def initialize( from: , to:, value: nil)
-      msg = "Error coercing from #{from} to #{to}."
+    def initialize( context: , from: , to:, value: nil)
+      msg = "Error coercing from #{from} to #{to} while loading #{Attributor.humanize_context(context)}."
       msg += " Received value #{value.inspect}" if value
       super msg
     end
   end
   
   class DeserializationError < LoadError
-    def initialize( from:, encoding: , value: nil)
-      msg = "Error deserializing a #{from} using #{encoding}."
+    def initialize( context: , from:, encoding: , value: nil)
+      msg = "Error deserializing a #{from} using #{encoding} while loading #{Attributor.humanize_context(context)}."
       msg += " Received value #{value.inspect}" if value
       super msg
     end  
   end
   
+  class DumpError < AttributorException
+    def initialize( context: , name: , type: , original_exception: )
+      msg = "Error while dumping attribute #{name} of type #{type} for context #{Attributor.humanize_context(context)} ."
+      msg << " Reason: #{original_exception}"
+      super msg
+    end
+  end
 end

--- a/lib/attributor/types/boolean.rb
+++ b/lib/attributor/types/boolean.rb
@@ -15,11 +15,11 @@ module Attributor
       [true, false].sample
     end
 
-    def self.load(value)
-      raise CoercionError, from: value.class, to: self, value: value  if value.is_a?(::Float)
+    def self.load(value,context=Attributor::DEFAULT_ROOT_CONTEXT)
+      raise CoercionError, context: context, from: value.class, to: self, value: value  if value.is_a?(::Float)
       return false if [ false, 'false', 'FALSE', '0', 0, 'f', 'F' ].include?(value)
       return true if [ true, 'true', 'TRUE', '1', 1, 't', 'T' ].include?(value)
-      raise CoercionError, from: value.class, to: self
+      raise CoercionError, context: context, from: value.class, to: self
     end
   end
 end

--- a/lib/attributor/types/container.rb
+++ b/lib/attributor/types/container.rb
@@ -10,8 +10,8 @@ module Attributor
 
     module ClassMethods
 
-      def decode_string(value)
-        raise "#{self.name}.decode_string is not implemented."
+      def decode_string(value, context=Attributor::DEFAULT_ROOT_CONTEXT)
+        raise "#{self.name}.decode_string is not implemented. (when decoding #{Attributor.humanize_context(context)})"
       end
 
       # Decode JSON string that encapsulates an array
@@ -19,8 +19,8 @@ module Attributor
       # @param value [String] JSON string
       # @return [Array] a normal Ruby Array
       #
-      def decode_json(value)
-        raise Attributor::DeserializationError, from: value.class, encoding: "JSON" , value: value unless value.kind_of? ::String
+      def decode_json(value, context=Attributor::DEFAULT_ROOT_CONTEXT)
+        raise Attributor::DeserializationError, context: context, from: value.class, encoding: "JSON" , value: value unless value.kind_of? ::String
 
         # attempt to parse as JSON
         parsed_value = JSON.parse(value)
@@ -28,12 +28,12 @@ module Attributor
         if parsed_value.is_a? self.native_type
           value = parsed_value
         else
-          raise Attributor::CoercionError, from: parsed_value.class, to: self.name, value: parsed_value
+          raise Attributor::CoercionError, context: context, from: parsed_value.class, to: self.name, value: parsed_value
         end
         return value
 
       rescue JSON::JSONError => e
-        raise Attributor::DeserializationError, from: value.class, encoding: "JSON" , value: value
+        raise Attributor::DeserializationError, context: context, from: value.class, encoding: "JSON" , value: value
       end
 
     end

--- a/lib/attributor/types/csv.rb
+++ b/lib/attributor/types/csv.rb
@@ -2,7 +2,7 @@ module Attributor
 
   class CSV < Collection
 
-    def self.decode_string(value)
+    def self.decode_string(value,context)
       value.split(',')
     end
 

--- a/lib/attributor/types/date_time.rb
+++ b/lib/attributor/types/date_time.rb
@@ -13,10 +13,10 @@ module Attributor
       end
 
       def self.example(context=nil, options: {})
-        return self.load(/[:date:]/.gen)
+        return self.load(/[:date:]/.gen, context)
       end
 
-      def self.load(value)
+      def self.load(value,context=Attributor::DEFAULT_ROOT_CONTEXT)
         # We assume that if the value is already in the right type, we've decoded it already
         return value if value.is_a?(self.native_type)
         return value.to_datetime if value.is_a?(::Time)
@@ -26,7 +26,7 @@ module Attributor
         begin
           return ::DateTime.parse(value)
         rescue ArgumentError => e
-          raise Attributor::DeserializationError, from: value.class, encoding: "DateTime" , value: value            
+          raise Attributor::DeserializationError, context: context, from: value.class, encoding: "DateTime" , value: value            
         end
       end
 

--- a/lib/attributor/types/float.rb
+++ b/lib/attributor/types/float.rb
@@ -17,7 +17,7 @@ module Attributor
       rand * (max-min) + min
     end
 
-    def self.load(value)
+    def self.load(value,context=Attributor::DEFAULT_ROOT_CONTEXT)
       if value.is_a?(::String)
         return Float(value)
       end

--- a/lib/attributor/types/integer.rb
+++ b/lib/attributor/types/integer.rb
@@ -34,7 +34,7 @@ module Attributor
       rand(max-min+1) + min
     end
 
-    def self.load(value)
+    def self.load(value,context=Attributor::DEFAULT_ROOT_CONTEXT)
       if value.is_a?(::String)
         return Integer(value)
       end

--- a/lib/attributor/types/string.rb
+++ b/lib/attributor/types/string.rb
@@ -7,7 +7,7 @@ module Attributor
     end
 
 
-    def self.load(value)
+    def self.load(value,context=Attributor::DEFAULT_ROOT_CONTEXT)
       # Special handling for Symbols. 
       case value
       when Symbol

--- a/spec/support/types.rb
+++ b/spec/support/types.rb
@@ -12,7 +12,7 @@ class IntegerAttributeType
     ::Integer
   end
 
-  def self.load(value)
+  def self.load(value,context=Attributor::DEFAULT_ROOT_CONTEXT)
     value.to_i
   end
 

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -38,9 +38,10 @@ describe Attributor::Type do
 
     context "when given a value that is not of native_type" do
       let(:value) { 1 }
-
+      let(:context) { ['top','sub'] }
+      
       it 'raises an exception' do
-        expect { test_type.load(value) }.to raise_error( Attributor::IncompatibleTypeError, /AttributeType cannot load values of type Fixnum/)
+        expect { test_type.load(value,context) }.to raise_error( Attributor::IncompatibleTypeError, /AttributeType cannot load values of type Fixnum.*while loading top.sub/)
       end
 
 
@@ -50,7 +51,7 @@ describe Attributor::Type do
 
 
   context 'validate' do
-    let(:context) { 'some_attribute'}
+    let(:context) { ['some_attribute'] }
 
     let(:attribute_options) { {} }
 

--- a/spec/types/boolean_spec.rb
+++ b/spec/types/boolean_spec.rb
@@ -65,13 +65,13 @@ describe Attributor::Boolean do
     end
 
     context 'that are not valid Booleans' do
-
+      let(:context){ ['root','subattr'] }
       ['string', 2, 1.0, Class, Object.new].each do |value|
 
         it "raises Attributor::CoercionError for #{value.inspect}" do
           expect {
-            type.load(value)
-          }.to raise_error(Attributor::CoercionError, /Error coercing from .+ to Attributor::Boolean/)
+            type.load(value,context)
+          }.to raise_error(Attributor::CoercionError, /Error coercing from .+ to Attributor::Boolean.* #{context.join('.')}/)
         end
 
       end

--- a/spec/types/container_spec.rb
+++ b/spec/types/container_spec.rb
@@ -4,6 +4,7 @@ require File.join(File.dirname(__FILE__), '../spec_helper.rb')
 describe Attributor::Container do
 
   context '.decode_json' do
+
     let(:mock_type) do
       Class.new do
         include Attributor::Container
@@ -35,6 +36,13 @@ describe Attributor::Container do
           mock_type.decode_json("{invalid_json}")
         }.to raise_error(Attributor::DeserializationError, /Error deserializing a String using JSON/)
       end
+      
+      it 'uses the passed context in the output error' do
+        expect{ 
+          mock_type.decode_json("{invalid_json}",["my_context","attribute_name"])
+        }.to raise_error(Attributor::DeserializationError, /Error deserializing a String using JSON.* while loading my_context.attribute_name/)
+      end
+
     end
   end
   

--- a/spec/types/ids_spec.rb
+++ b/spec/types/ids_spec.rb
@@ -17,7 +17,7 @@ describe Attributor::Ids do
     end
 
     it 'generates valid examples' do
-      ids.validate(ids.example,nil,nil).should be_empty
+      ids.validate(ids.example).should be_empty
     end
 
   end


### PR DESCRIPTION
- Added contextual information while loading and dumping attributes.
  - #load takes a new context argument (defaulting to a system-wide root) in the form of an array of parent segments.
  - #validate takes a context argument that (instead of a string) is now an array of parent segments.
  - #dump takes a context: option parameter of the same type
- Enhanced error messages to report the correct context scope.
