### PR TITLE
Support reopening Model attributes to add or replace existing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ next
   * Make Attribute assignments in models to report a special context (not the attributor root) 
     * Instead of reporting "$." as the context , when doing model.field_name=value, they'll now report "assignment.of(field_name)" instead
   * Truncate the lenght of values when reporting loading errors when they're long (i.e. >500 chars)
+* `Model.attributes` may now be called more than once to set add or replace attributes. The exact behavior depends upon the types of the attributes being added or replaced. See [model_spec.rb](spec/types/model_spec.rb) for examples.
 
 
 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ group :development do
   gem 'simplecov'
   gem 'guard'
   gem 'guard-rspec'
+
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'pry-stack_explorer'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,12 @@ GEM
   specs:
     addressable (2.3.6)
     backports (3.6.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     builder (3.2.2)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     celluloid-io (0.15.0)
@@ -25,11 +30,14 @@ GEM
       nio4r (>= 0.5.0)
     coderay (1.1.0)
     colored (1.2)
+    columnize (0.3.6)
     cucumber (1.3.2)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12.0)
       multi_json (~> 1.3)
+    debug_inspector (0.0.2)
+    debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
     faraday (0.8.9)
@@ -94,6 +102,12 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
+    pry-stack_explorer (0.4.9.1)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     rack (1.5.2)
     rake (0.9.6)
     rake-notes (0.2.0)
@@ -146,6 +160,9 @@ DEPENDENCIES
   guard-rspec
   hashie
   jeweler (~> 1.8.3)
+  pry
+  pry-byebug
+  pry-stack_explorer
   rake-notes
   randexp
   rdoc (~> 3.12)

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -121,12 +121,10 @@ module Attributor
 
 
     def attributes
-      @attributes ||= begin
-        if type.respond_to?(:attributes)
-          type.attributes
-        else
-          nil
-        end
+      if (@type_has_attributes ||= type.respond_to?(:attributes))
+        type.attributes
+      else
+        nil
       end
     end
 

--- a/lib/attributor/dsl_compiler.rb
+++ b/lib/attributor/dsl_compiler.rb
@@ -62,8 +62,14 @@ module Attributor
     #       attribute :state, String
     #     end
     def attribute(name, type_or_options=nil, opts={}, &block)
-      raise AttributorException.new("Attribute #{name} already defined") if attributes.has_key? name
       raise AttributorException, "Attribute names must be symbols, got: #{name.inspect}" unless name.kind_of? ::Symbol
+
+      if (existing_attribute = attributes[name])
+        if existing_attribute.attributes
+          existing_attribute.type.attributes(&block)
+          return existing_attribute
+        end
+      end
 
       attr_type, opts = self.parse_arguments(type_or_options, opts)
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -41,20 +41,19 @@ class Turducken < Attributor::Model
 end
 
 
-    # http://en.wikipedia.org/wiki/Cormorant
-    class Cormorant < Attributor::Model
+# http://en.wikipedia.org/wiki/Cormorant
+class Cormorant < Attributor::Model
+  attributes do
+    # This will be a collection of arbitrary Ruby Objects
+    attribute :fish, Attributor::Collection, :description => "All kinds of fish for feeding the babies"
 
-      attributes do
-        # This will be a collection of arbitrary Ruby Objects
-        attribute :fish, Attributor::Collection, :description => "All kinds of fish for feeding the babies"
+    # This will be a collection of Cormorants (note, this relationship is circular)
+    attribute :neighbors, Attributor::Collection.of(Cormorant), :description => "Neighbor cormorants"
 
-        # This will be a collection of Cormorants (note, this relationship is circular)
-        attribute :neighbors, Attributor::Collection.of(Cormorant), :description => "Neighbor cormorants"
+    # This will be a collection of instances of an anonymous Struct class, each having two well-defined attributes
 
-        # This will be a collection of instances of an anonymous Struct class, each having two well-defined attributes
-
-        attribute :babies, Attributor::Collection.of(Attributor::Struct), :description => "All the babies", :member_options => {:identity => 'name'} do
-          attribute :name, Attributor::String, :example => /[:name]/, :description => "The name of the baby cormorant"
+    attribute :babies, Attributor::Collection.of(Attributor::Struct), :description => "All the babies", :member_options => {:identity => 'name'} do
+      attribute :name, Attributor::String, :example => /[:name]/, :description => "The name of the baby cormorant"
       attribute :months, Attributor::Integer, :default => 0, :min => 0, :description => "The age in months of the baby cormorant"
       attribute :weight, Attributor::Float, :example => /\d{1,2}\.\d{3}/, :description => "The weight in kg of the baby cormorant"
     end
@@ -80,4 +79,3 @@ class Address < Attributor::Model
     attribute :person, Person, example: proc { |address, context| Person.example(context, address: address) }
   end
 end
-

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -342,4 +342,61 @@ describe Attributor::Model do
 
 
   end
+
+  context 'extending' do
+    subject(:model) do
+      Class.new(Attributor::Model) do
+        attributes do
+          attribute :id, Integer
+          attribute :timestamps do
+            attribute :created_at, DateTime
+          end
+        end
+      end
+    end
+
+    context 'adding a top-level attribute' do
+      before do
+        model.attributes do
+          attribute :name, String
+        end
+      end
+
+      it 'adds the attribute' do
+        model.attributes.keys.should =~ [:id, :name, :timestamps]
+      end
+
+    end
+
+    context 'adding to an inner-Struct' do
+      before do
+        model.attributes do
+          attribute :timestamps, Struct do
+            attribute :updated_at, DateTime
+          end
+        end
+      end
+
+      it 'merges with sub-attributes' do
+        model.attributes[:timestamps].attributes.keys.should =~ [:created_at, :updated_at]
+      end
+    end
+
+
+    context 'redefining an attribute' do
+      before do
+        model.attributes do
+          attribute :id, String
+        end
+      end
+
+      it 'works' do
+        model.attributes[:id].type.should be(Attributor::String)
+      end
+
+    end
+
+  end
+
+
 end


### PR DESCRIPTION
Model.attributes may now be called more than once to set add or replace attributes.
