### PR TITLE
sapphire_14_15_acu176592_undef_namespace_in_model

### DIFF
--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -7,6 +7,7 @@ module Attributor
     # FIXME: this is not the way to fix this. Really we should add finalize! to Models.
     undef :timeout
     undef :format
+    undef :namespace  # conflict with 'rake' gem DSL
 
     def self.inherited(klass)
       klass.instance_eval do


### PR DESCRIPTION
@careo undefine :namespace on model to avoid conflict with rake 'namespace' idiom during rspec runs
