### PR TITLE
sapphire_14_15_acu176592_undef_namespace_in_model

### DIFF
--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -7,7 +7,13 @@ module Attributor
     # FIXME: this is not the way to fix this. Really we should add finalize! to Models.
     undef :timeout
     undef :format
-    undef :namespace  # conflict with 'rake' gem DSL
+
+    if defined?(:namespace)
+      # conflict with 'rake' gem < 10.0 DSL. the rescue is needed because
+      # rake v10 appears to define this in a better way than v9 and although it
+      # is defined?=true it doesn't need to be undef'd
+      undef :namespace rescue nil
+    end
 
     def self.inherited(klass)
       klass.instance_eval do


### PR DESCRIPTION
@careo undefine :namespace on model to avoid conflict with rake 'namespace' idiom during rspec runs
be more careful about whether :namespace is defined?
