### PR TITLE
Fix example generation for Hash and Collection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Attributor Changelog
 next
 ------
 
-* First new feature here
+* Fix example generation for Hash and Collection to handle a non-Array context parameter.
 
 2.1.0
 ------

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -43,7 +43,8 @@ module Attributor
       result = []
       size = rand(3) + 1
       context ||= ["Collection-#{result.object_id}"]
-
+      context = Array(context)
+      
       size.times do |i|
         subcontext = context + ["at(#{i})"]
         result << self.member_attribute.example(subcontext)

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -120,7 +120,8 @@ module Attributor
       return self.new if (key_type == Object && value_type == Object)
 
       hash = ::Hash.new
-      # Let's not bother to generate any hash contents if there's absolutely no type defined
+      context ||= ["#{Hash}-#{rand(10000000)}"]
+      context = Array(context)
 
       if self.keys.any?
         self.keys.each do |sub_name, sub_attribute|
@@ -128,12 +129,8 @@ module Attributor
           hash[sub_name] = sub_attribute.example(subcontext)
         end
       else
-
         size = rand(3) + 1
-
-        context ||= ["#{Hash}-#{rand(10000000)}"]
-        context = Array(context)
-
+        
         size.times do |i|
           example_key = key_type.example(context + ["at(#{i})"])
           subcontext = context + ["at(#{example_key})"]

--- a/spec/types/collection_spec.rb
+++ b/spec/types/collection_spec.rb
@@ -282,5 +282,13 @@ describe Attributor::Collection do
         value.all? { |element| member_type.valid_type?(element) }.should be_true
       end
     end
+    context "passing a non array context" do
+      it 'still is handled correctly ' do
+        expect{
+          type.example("SimpleString")
+        }.to_not raise_error
+      end
+    end
+    
   end
 end

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -25,6 +25,17 @@ describe Attributor::Hash do
         example.values.all? {|v| v.kind_of? Integer}.should be(true)
       end
     end
+    context 'using a non array context' do
+      it 'should work for hashes with key/value types' do
+        expect{ Attributor::Hash.of(key:String,value:String).example("Not an Array") }.to_not raise_error
+      end
+      it 'should work for hashes with keys defined' do
+        block = proc { key 'a string', String }
+        hash = Attributor::Hash.of(key:String).construct(block)
+
+        expect{ hash.example("Not an Array") }.to_not raise_error
+      end
+    end
   end
 
   context '.load' do


### PR DESCRIPTION
- They will now wrap the context param into an Array if it is not.

Fixes #80

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
