### PR TITLE
Type description changes:

### DIFF
--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -70,7 +70,7 @@ module Attributor
 
 
     TOP_LEVEL_OPTIONS = [ :description, :values, :default, :example, :required, :required_if ]
-    INTERNAL_OPTIONS = [:dsl_compiler] # Options we don't want to expose when describing attributes
+    INTERNAL_OPTIONS = [:dsl_compiler,:dsl_compiler_options] # Options we don't want to expose when describing attributes
     def describe(shallow=true)
       description = { } 
       # Clone the common options

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -85,7 +85,7 @@ module Attributor
       #puts "Collection: #{self.type}"      
       hash = super(shallow)
       hash[:options] = {} unless hash[:options]
-      hash[:options][:member_attribute] = self.member_attribute.describe
+      hash[:member_attribute] = self.member_attribute.describe
       hash
     end
 


### PR DESCRIPTION
- In Collection.describe, move member_attribute from inside options to top level.
- Add dsl_compiler_options option to be internal and never reported when describing an attribute

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
