### PR TITLE
Enhance Hash and Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ next
 
 * Dumping attributes will now load the values if they're not in the native type.
 * `Model.valid_type?` now accepts hashes.
+* `Hash`:
+  * Added `:has_key?` to delegation
 
 2.2.0
 ------

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -308,7 +308,7 @@ module Attributor
     # TODO: add a validate, which simply validates that the incoming keys and values are of the right type.
     #       Think about the format of the subcontexts to use: let's use .at(key.to_s)
     attr_reader :contents
-    def_delegators :@contents, :[], :[]=, :each, :size, :keys, :key?, :values, :empty?
+    def_delegators :@contents, :[], :[]=, :each, :size, :keys, :key?, :values, :empty?, :has_key?
 
     def initialize(contents={})
       @contents = contents


### PR DESCRIPTION
Add `Model.valid_type?` to accept hashes, and add `:has_key?` to Hash delegation.
