### PR TITLE
Fixes open hashes to output example if given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+* Fixed describing `Hash` with no keys defined, to still use a given example (no example outputted before this)
+
 ## 5.1
 
 * Added `Polymorphic` type. See [polymorphics.rb](spec/support/polymorphics.rb) for example usage.

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -436,6 +436,7 @@ module Attributor
         end
       else
         hash[:value] = { type: value_type.describe(true) }
+        hash[:example] = example if example
       end
 
       hash

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -687,6 +687,13 @@ describe Attributor::Hash do
         expect(description[:name]).to eq('Hash')
         expect(description[:key]).to eq(type: { name: 'Object', id: 'Attributor-Object', family: 'any' })
         expect(description[:value]).to eq(type: { name: 'Object', id: 'Attributor-Object', family: 'any' })
+        expect(description).to_not have_key(:example)
+      end
+      context 'when there is a given example' do
+        let(:example) { { 'one' => 1, two: 2} }
+        it 'uses it, even though there are not individual keys' do
+          expect(description[:example]).to eq(example)
+        end
       end
     end
 


### PR DESCRIPTION
* Fixed describing `Hash` with no keys defined, to still use a given example (no example outputted before this)


Signed-off-by: Josep M. Blanquer <blanquer@gmail.com>