### PR TITLE
Overriding attributes from Collection references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## next
 
 * Fixed describing `Hash` with no keys defined, to still use a given example (no example outputted before this)
-* Bix bug that would occur when defining an attribute carrying a reference object, for which the reference type didn't have `attributes` (for example a Collection).
+* Fix bug that would occur when defining an attribute carrying a reference object, for which the reference type didn't have `attributes` (for example a Collection).
 
 ## 5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 * Fixed describing `Hash` with no keys defined, to still use a given example (no example outputted before this)
+* Bix bug that would occur when defining an attribute carrying a reference object, for which the reference type didn't have `attributes` (for example a Collection).
 
 ## 5.1
 

--- a/lib/attributor/dsl_compiler.rb
+++ b/lib/attributor/dsl_compiler.rb
@@ -89,7 +89,8 @@ module Attributor
       # determine inherited attribute
       inherited_attribute = nil
       if (reference = options[:reference])
-        if (inherited_attribute = reference.attributes[name])
+        if reference.respond_to?(:attributes) && reference.attributes[name]
+          inherited_attribute = reference.attributes[name]
           opts = inherited_attribute.options.merge(opts) unless attr_type
           opts[:reference] = inherited_attribute.type if block_given?
         end

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -690,7 +690,7 @@ describe Attributor::Hash do
         expect(description).to_not have_key(:example)
       end
       context 'when there is a given example' do
-        let(:example) { { 'one' => 1, two: 2} }
+        let(:example) { { 'one' => 1, two: 2 } }
         it 'uses it, even though there are not individual keys' do
           expect(description[:example]).to eq(example)
         end


### PR DESCRIPTION
Fixes bug that would occur when defining an attribute carrying a reference object, for which the reference type didn't have `attributes` (for example a reference being a Collection but the override attribute being a Hash/Model attribute).

Signed-off-by: Josep M. Blanquer <blanquer@gmail.com>