### PR TITLE
Allows attribute to override the reference option of its parent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed describing `Hash` with no keys defined, to still use a given example (no example outputted before this)
 * Fix bug that would occur when defining an attribute carrying a reference object, for which the reference type didn't have `attributes` (for example a Collection).
+* Allows an attribute to override the reference object through its options of its parent (even when its containing object already has one defined).
 
 ## 5.1
 

--- a/spec/dsl_compiler_spec.rb
+++ b/spec/dsl_compiler_spec.rb
@@ -66,6 +66,16 @@ describe Attributor::DSLCompiler do
           it 'accepts explicit nil type' do
             dsl_compiler.attribute(attribute_name, nil, attribute_options)
           end
+
+          context 'but with the attribute also specifying a reference' do
+            let(:attribute_options) { { reference: Attributor::CSV } }
+            let(:expected_type) { Attributor::CSV }
+            let(:expected_options) { attribute_options }
+            it 'attribute reference takes precedence over the compiler one (and merges no options)' do
+              expect(attribute_options[:reference]).to_not eq(dsl_compiler_options[:reference])
+              dsl_compiler.attribute(attribute_name, attribute_options)
+            end
+          end
         end
 
         context 'for a referenced Model attribute' do


### PR DESCRIPTION

Passing the `:reference` option in an attribute would not take effect if the containing object of the attribute already had a `:reference` defined. This PR makes sure that a `:reference` option used in an attribute overrides any existing one coming from the objects above.

Signed-off-by: Josep M. Blanquer <blanquer@gmail.com>