### PR TITLE
Pass kwargs through Model.dump to attributes

### DIFF
--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -192,7 +192,7 @@ module Attributor
           next
         end
 
-        hash[name.to_sym] = attribute.dump(value, context: context + [name])
+        hash[name.to_sym] = attribute.dump(value, context: context + [name], **_opts)
       end
     ensure
       @dumping = false

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -413,6 +413,17 @@ describe Attributor::Model do
         expect(person.address.person).to be(person)
         expect(output[:address][:person]).to eq(Attributor::Model::CIRCULAR_REFERENCE_MARKER)
       end
+
+      it 'passes kwargs' do
+        person.class.attributes.values.each do |attr|
+          expect(attr).to receive(:dump).with(
+            anything,
+            context: anything,
+            custom_arg: :custom_value
+          )
+        end
+        person.dump(custom_arg: :custom_value)
+      end
     end
   end
 


### PR DESCRIPTION
Model.dump currently drops the passed in kwargs in _opts when they should be passed to the underlying attribute.dump calls.