### PR TITLE
Ruby 2.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 script:
   - bundle exec rspec spec
 branches:

--- a/attributor.gemspec
+++ b/attributor.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec-its'
-  spec.add_development_dependency 'rspec-collection_matchers', '~> 1'
+  spec.add_development_dependency 'rspec-collection_matchers'
   spec.add_development_dependency('yard')
   spec.add_development_dependency('backports', ['~> 3'])
   spec.add_development_dependency('yardstick', ['~> 0'])
@@ -34,10 +34,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('coveralls')
   spec.add_development_dependency('guard', ['~> 2'])
   spec.add_development_dependency('guard-rspec', ['~> 4'])
-  spec.add_development_dependency('pry', ['~> 0'])
+  spec.add_development_dependency('pry')
   if RUBY_PLATFORM !~ /java/
-    spec.add_development_dependency('pry-byebug', ['~> 1'])
-    spec.add_development_dependency('pry-stack_explorer', ['~> 0'])
+    spec.add_development_dependency('pry-byebug')
+    spec.add_development_dependency('pry-stack_explorer')
   end
   spec.add_development_dependency 'fuubar'
   spec.add_development_dependency 'rubocop'

--- a/lib/attributor.rb
+++ b/lib/attributor.rb
@@ -29,7 +29,7 @@ module Attributor
   def self.resolve_type(attr_type, options = {}, constructor_block = nil)
     klass = self.find_type(attr_type)
 
-    return klass.construct(constructor_block, options) if klass.constructable?
+    return klass.construct(constructor_block, **options) if klass.constructable?
     raise AttributorException, "Type: #{attr_type} does not support anonymous generation" if constructor_block
 
     klass

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -166,7 +166,7 @@ module Attributor
       return options[:values].pick if options.key? :values
 
       if type.respond_to?(:attributes)
-        type.example(context, values)
+        type.example(context, **values)
       else
         type.example(context, options: options)
       end

--- a/lib/attributor/hash_dsl_compiler.rb
+++ b/lib/attributor/hash_dsl_compiler.rb
@@ -89,31 +89,31 @@ module Attributor
       end
 
       def all(*attr_names, **opts)
-        req = Requirement.new(options.merge(opts).merge(all: attr_names))
+        req = Requirement.new(**options.merge(opts).merge(all: attr_names))
         target.add_requirement req
         req
       end
 
       def at_most(number)
-        req = Requirement.new(options.merge(at_most: number))
+        req = Requirement.new(**options.merge(at_most: number))
         target.add_requirement req
         req
       end
 
       def at_least(number)
-        req = Requirement.new(options.merge(at_least: number))
+        req = Requirement.new(**options.merge(at_least: number))
         target.add_requirement req
         req
       end
 
       def exactly(number)
-        req = Requirement.new(options.merge(exactly: number))
+        req = Requirement.new(**options.merge(exactly: number))
         target.add_requirement req
         req
       end
 
       def exclusive(*attr_names, **opts)
-        req = Requirement.new(options.merge(opts).merge(exclusive: attr_names))
+        req = Requirement.new(**options.merge(opts).merge(exclusive: attr_names))
         target.add_requirement req
         req
       end
@@ -132,7 +132,7 @@ module Attributor
           _requirements_dsl
         end
       else
-        _requirements_dsl.all(*spec, opts)
+        _requirements_dsl.all(*spec, **opts)
       end
     end
   end

--- a/lib/attributor/type.rb
+++ b/lib/attributor/type.rb
@@ -29,7 +29,7 @@ module Attributor
       def load(value, context = Attributor::DEFAULT_ROOT_CONTEXT, **_options)
         return nil if value.nil?
         unless value.is_a?(native_type)
-          raise Attributor::IncompatibleTypeError, context: context, value_type: value.class, type: self
+          raise Attributor::IncompatibleTypeError.new(context: context, value_type: value.class, type: self)
         end
 
         value

--- a/lib/attributor/types/bigdecimal.rb
+++ b/lib/attributor/types/bigdecimal.rb
@@ -7,7 +7,7 @@ module Attributor
     end
 
     def self.example(_context = nil, options: {})
-      ::BigDecimal.new("#{/\d{3}/.gen}.#{/\d{3}/.gen}")
+      BigDecimal("#{/\d{3}/.gen}.#{/\d{3}/.gen}")
     end
 
     def self.load(value, _context = Attributor::DEFAULT_ROOT_CONTEXT, **_options)

--- a/lib/attributor/types/boolean.rb
+++ b/lib/attributor/types/boolean.rb
@@ -17,10 +17,10 @@ module Attributor
     def self.load(value, context = Attributor::DEFAULT_ROOT_CONTEXT, **_options)
       return nil if value.nil?
 
-      raise CoercionError, context: context, from: value.class, to: self, value: value if value.is_a?(::Float)
+      raise CoercionError.new(context: context, from: value.class, to: self, value: value) if value.is_a?(::Float)
       return false if [false, 'false', 'FALSE', '0', 0, 'f', 'F'].include?(value)
       return true if [true, 'true', 'TRUE', '1', 1, 't', 'T'].include?(value)
-      raise CoercionError, context: context, from: value.class, to: self
+      raise CoercionError.new(context: context, from: value.class, to: self)
     end
 
     def self.family

--- a/lib/attributor/types/class.rb
+++ b/lib/attributor/types/class.rb
@@ -16,7 +16,7 @@ module Attributor
 
       # Must be given a String object or nil
       unless value.is_a?(::String) || value.nil?
-        raise IncompatibleTypeError,  context: context, value_type: value.class, type: self
+        raise IncompatibleTypeError.new(context: context, value_type: value.class, type: self)
       end
 
       value = '::' + value if value[0..1] != '::'

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -51,7 +51,7 @@ module Attributor
 
     def self.member_attribute
       @member_attribute ||= begin
-        construct(nil, {})
+        construct(nil)
 
         @member_attribute
       end
@@ -91,7 +91,7 @@ module Attributor
       elsif value.respond_to?(:to_a)
         loaded_value = value.to_a
       else
-        raise Attributor::IncompatibleTypeError, context: context, value_type: value.class, type: self
+        raise Attributor::IncompatibleTypeError.new(context: context, value_type: value.class, type: self)
       end
 
       new(loaded_value.collect { |member| member_attribute.load(member, context) })
@@ -103,7 +103,7 @@ module Attributor
 
     def self.dump(values, **opts)
       return nil if values.nil?
-      values.collect { |value| member_attribute.dump(value, opts) }
+      values.collect { |value| member_attribute.dump(value, **opts) }
     end
 
     def self.describe(shallow = false, example: nil)
@@ -121,7 +121,7 @@ module Attributor
       true
     end
 
-    def self.construct(constructor_block, options)
+    def self.construct(constructor_block, **options)
       member_options = (options[:member_options] || {}).clone
       if options.key?(:reference) && !member_options.key?(:reference)
         member_options[:reference] = options[:reference]
@@ -173,7 +173,7 @@ module Attributor
     end
 
     def dump(**opts)
-      collect { |value| self.class.member_attribute.dump(value, opts) }
+      collect { |value| self.class.member_attribute.dump(value, **opts) }
     end
   end
 end

--- a/lib/attributor/types/container.rb
+++ b/lib/attributor/types/container.rb
@@ -19,17 +19,17 @@ module Attributor
       # @return [Array] a normal Ruby Array
       #
       def decode_json(value, context = Attributor::DEFAULT_ROOT_CONTEXT)
-        raise Attributor::DeserializationError, context: context, from: value.class, encoding: 'JSON', value: value unless value.is_a? ::String
+        raise Attributor::DeserializationError.new(context: context, from: value.class, encoding: 'JSON', value: value) unless value.is_a? ::String
 
         # attempt to parse as JSON
         parsed_value = JSON.parse(value)
         unless valid_type?(parsed_value)
-          raise Attributor::CoercionError, context: context, from: parsed_value.class, to: name, value: parsed_value
+          raise Attributor::CoercionError.new(context: context, from: parsed_value.class, to: name, value: parsed_value)
         end
 
         parsed_value
       rescue JSON::JSONError
-        raise Attributor::DeserializationError, context: context, from: value.class, encoding: 'JSON', value: value
+        raise Attributor::DeserializationError.new(context: context, from: value.class, encoding: 'JSON', value: value)
       end
     end
   end

--- a/lib/attributor/types/csv.rb
+++ b/lib/attributor/types/csv.rb
@@ -9,7 +9,7 @@ module Attributor
       when ::String
         values
       when ::Array
-        values.collect { |value| member_attribute.dump(value, opts).to_s }.join(',')
+        values.collect { |value| member_attribute.dump(value, **opts).to_s }.join(',')
       when nil
         nil
       else

--- a/lib/attributor/types/date.rb
+++ b/lib/attributor/types/date.rb
@@ -21,10 +21,10 @@ module Attributor
         begin
           return ::Date.parse(value)
         rescue ArgumentError
-          raise Attributor::DeserializationError, context: context, from: value.class, encoding: 'Date', value: value
+          raise Attributor::DeserializationError.new(context: context, from: value.class, encoding: 'Date', value: value)
         end
       else
-        raise CoercionError, context: context, from: value.class, to: self, value: value
+        raise CoercionError.new(context: context, from: value.class, to: self, value: value)
       end
     end
   end

--- a/lib/attributor/types/date_time.rb
+++ b/lib/attributor/types/date_time.rb
@@ -24,7 +24,7 @@ module Attributor
       begin
         return ::DateTime.parse(value)
       rescue ArgumentError
-        raise Attributor::DeserializationError, context: context, from: value.class, encoding: 'DateTime', value: value
+        raise Attributor::DeserializationError.new(context: context, from: value.class, encoding: 'DateTime', value: value)
       end
     end
   end

--- a/lib/attributor/types/hash.rb
+++ b/lib/attributor/types/hash.rb
@@ -82,7 +82,7 @@ module Attributor
     def self.attributes(**options, &key_spec)
       raise @error if @error
 
-      keys(options, &key_spec)
+      keys(**options, &key_spec)
     end
 
     def self.keys(**options, &key_spec)
@@ -111,7 +111,7 @@ module Attributor
       }.merge(@options)
 
       blocks = @saved_blocks.shift(@saved_blocks.size)
-      compiler = dsl_class.new(self, opts)
+      compiler = dsl_class.new(self, **opts)
       compiler.parse(*blocks)
 
       if opts[:case_insensitive_load] == true
@@ -171,7 +171,7 @@ module Attributor
         raise Attributor::AttributorException, ":case_insensitive_load may not be used with keys of type #{key_type.name}"
       end
 
-      keys(options, &constructor_block)
+      keys(**options, &constructor_block)
       self
     end
 
@@ -221,7 +221,7 @@ module Attributor
         result = new
         result.extend(ExampleMixin)
 
-        result.lazy_attributes = example_contents(context, result, values)
+        result.lazy_attributes = example_contents(context, result, **values)
       else
         hash = ::Hash.new
 
@@ -285,7 +285,7 @@ module Attributor
       elsif value.respond_to?(:to_hash)
         value.to_hash
       else
-        raise Attributor::IncompatibleTypeError, context: context, value_type: value.class, type: self
+        raise Attributor::IncompatibleTypeError.new(context: context, value_type: value.class, type: self)
       end
     end
 
@@ -607,12 +607,12 @@ module Attributor
       @dumping = true
 
       contents.each_with_object({}) do |(k, v), hash|
-        k = key_attribute.dump(k, opts)
+        k = key_attribute.dump(k, **opts)
 
         v = if (attribute_for_value = self.class.keys[k])
-              attribute_for_value.dump(v, opts)
+              attribute_for_value.dump(v, **opts)
             else
-              value_attribute.dump(v, opts)
+              value_attribute.dump(v, **opts)
             end
 
         hash[k] = v

--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -105,7 +105,7 @@ module Attributor
         result = new
         result.extend(ExampleMixin)
 
-        result.lazy_attributes = example_contents(context, result, values)
+        result.lazy_attributes = example_contents(context, result, **values)
       else
         result = new
       end

--- a/lib/attributor/types/string.rb
+++ b/lib/attributor/types/string.rb
@@ -8,7 +8,7 @@ module Attributor
 
     def self.load(value, context = Attributor::DEFAULT_ROOT_CONTEXT, **options)
       if value.is_a?(Enumerable)
-        raise IncompatibleTypeError, context: context, value_type: value.class, type: self
+        raise IncompatibleTypeError.new(context: context, value_type: value.class, type: self)
       end
 
       value && String(value)

--- a/lib/attributor/types/struct.rb
+++ b/lib/attributor/types/struct.rb
@@ -26,7 +26,7 @@ module Attributor
       end
 
       ::Class.new(self) do
-        attributes options, &attribute_definition
+        attributes **options, &attribute_definition
       end
     end
 

--- a/lib/attributor/types/time.rb
+++ b/lib/attributor/types/time.rb
@@ -29,7 +29,7 @@ module Attributor
         begin
           return ::Time.parse(value)
         rescue ArgumentError
-          raise Attributor::DeserializationError, context: context, from: value.class, encoding: 'Time', value: value
+          raise Attributor::DeserializationError.new(context: context, from: value.class, encoding: 'Time', value: value)
         end
       else
         raise CoercionError, context: context, from: value.class, to: self, value: value

--- a/lib/attributor/types/uri.rb
+++ b/lib/attributor/types/uri.rb
@@ -34,7 +34,7 @@ module Attributor
       when ::String
         URI(value)
       else
-        raise CoercionError, context: context, from: value.class, to: self, value: value
+        raise CoercionError.new(context: context, from: value.class, to: self, value: value)
       end
     end
 

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -313,7 +313,11 @@ describe Attributor::Attribute do
     let(:value) { '1' }
 
     it 'delegates to type.load' do
-      expect(type).to receive(:load).with(value, context, {})
+      # Need to add the "anything" of the 3rd element, as in ruby < 2.7 it comes as an empty hash
+      expect(type).to receive(:load) do |v, c, _other|
+        expect(v).to eq(value)
+        expect(c).to eq(context)
+      end   
       attribute.load(value, context)
     end
 

--- a/spec/dsl_compiler_spec.rb
+++ b/spec/dsl_compiler_spec.rb
@@ -4,7 +4,7 @@ describe Attributor::DSLCompiler do
   let(:target) { double('model', attributes: {}) }
 
   let(:dsl_compiler_options) { {} }
-  subject(:dsl_compiler) { Attributor::DSLCompiler.new(target, dsl_compiler_options) }
+  subject(:dsl_compiler) { Attributor::DSLCompiler.new(target, **dsl_compiler_options) }
 
   let(:attribute_name) { :name }
   let(:type) { Attributor::String }
@@ -35,7 +35,7 @@ describe Attributor::DSLCompiler do
 
         it 'creates an attribute given a name, type, and options' do
           expect(Attributor::Attribute).to receive(:new).with(expected_type, expected_options)
-          dsl_compiler.attribute(attribute_name, type, attribute_options)
+          dsl_compiler.attribute(attribute_name, type, **attribute_options)
         end
       end
 
@@ -60,11 +60,11 @@ describe Attributor::DSLCompiler do
           end
 
           it 'creates an attribute with the inherited type and merged options' do
-            dsl_compiler.attribute(attribute_name, attribute_options)
+            dsl_compiler.attribute(attribute_name, **attribute_options)
           end
 
           it 'accepts explicit nil type' do
-            dsl_compiler.attribute(attribute_name, nil, attribute_options)
+            dsl_compiler.attribute(attribute_name, nil, **attribute_options)
           end
 
           context 'but with the attribute also specifying a reference' do
@@ -73,7 +73,7 @@ describe Attributor::DSLCompiler do
             let(:expected_options) { attribute_options }
             it 'attribute reference takes precedence over the compiler one (and merges no options)' do
               expect(attribute_options[:reference]).to_not eq(dsl_compiler_options[:reference])
-              dsl_compiler.attribute(attribute_name, attribute_options)
+              dsl_compiler.attribute(attribute_name, **attribute_options)
             end
           end
         end
@@ -113,12 +113,12 @@ describe Attributor::DSLCompiler do
         it 'sets the type of the attribute to Struct' do
           expect(Attributor::Attribute).to receive(:new)
             .with(expected_type, description: 'The turkey', reference: Turkey)
-          dsl_compiler.attribute(attribute_name, attribute_options, &attribute_block)
+          dsl_compiler.attribute(attribute_name, **attribute_options, &attribute_block)
         end
 
         it 'passes the correct reference to the created attribute' do
           expect(Attributor::Attribute).to receive(:new).with(expected_type, expected_options)
-          dsl_compiler.attribute(attribute_name, type, attribute_options, &attribute_block)
+          dsl_compiler.attribute(attribute_name, type, **attribute_options, &attribute_block)
         end
       end
     end

--- a/spec/hash_dsl_compiler_spec.rb
+++ b/spec/hash_dsl_compiler_spec.rb
@@ -4,7 +4,7 @@ describe Attributor::HashDSLCompiler do
   let(:target) { double('model', attributes: {}) }
 
   let(:dsl_compiler_options) { {} }
-  subject(:dsl_compiler) { Attributor::HashDSLCompiler.new(target, dsl_compiler_options) }
+  subject(:dsl_compiler) { Attributor::HashDSLCompiler.new(target, **dsl_compiler_options) }
 
   it 'returns the requirements DSL attached to the right target' do
     req_dsl = dsl_compiler._requirements_dsl
@@ -103,7 +103,7 @@ describe Attributor::HashDSLCompiler do
     end
 
     context 'Requirement#validate' do
-      let(:requirement) { req_class.new(arguments) }
+      let(:requirement) { req_class.new(**arguments) }
       let(:subject) { requirement.validate(value, ['$'], nil) }
 
       context 'for :all' do

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -68,7 +68,7 @@ describe Attributor::Type do
       let(:context) { %w(top sub) }
 
       it 'raises an exception' do
-        expect { test_type.load(value, context) }.to raise_error(Attributor::IncompatibleTypeError, /cannot load values of type Fixnum.*while loading top.sub/)
+        expect { test_type.load(value, context) }.to raise_error(Attributor::IncompatibleTypeError, /cannot load values of type (Fixnum|Integer).*while loading top.sub/)
       end
     end
   end

--- a/spec/types/hash_spec.rb
+++ b/spec/types/hash_spec.rb
@@ -359,7 +359,7 @@ describe Attributor::Hash do
       context 'with unknown keys in input' do
         it 'raises an error' do
           expect do
-            type.load('other_key' => :value)
+            type.load({'other_key' => :value})
           end.to raise_error(Attributor::AttributorException)
         end
       end
@@ -453,7 +453,7 @@ describe Attributor::Hash do
 
     context 'for a simple (untyped) hash' do
       it 'returns the untouched hash value' do
-        expect(type.dump(value, opts)).to eq(value)
+        expect(type.dump(value, **opts)).to eq(value)
       end
     end
 
@@ -475,7 +475,7 @@ describe Attributor::Hash do
       let(:type) { Attributor::Hash.of(key: String, value: subtype) }
 
       it 'returns a hash with the dumped values and keys' do
-        dumped_value = type.dump(value, opts)
+        dumped_value = type.dump(value, **opts)
         expect(dumped_value).to be_kind_of(::Hash)
         expect(dumped_value.keys).to match_array %w(id1 id2)
         expect(dumped_value.values).to have(2).items
@@ -487,7 +487,7 @@ describe Attributor::Hash do
         let(:value) { { id1: nil, id2: subtype.new(value2) } }
 
         it 'correctly returns nil rather than trying to dump their contents' do
-          dumped_value = type.dump(value, opts)
+          dumped_value = type.dump(value, **opts)
           expect(dumped_value).to be_kind_of(::Hash)
           expect(dumped_value.keys).to match_array %w(id1 id2)
           expect(dumped_value['id1']).to be nil
@@ -706,7 +706,7 @@ describe Attributor::Hash do
           expect(ex.keys).to match([:req1, :req2, :exc3, :least1, :least2, :most1])
         end
         it 'it favors picking attributes with data' do
-          ex = type.example(nil,{most2: "data"})
+          ex = type.example(nil,most2: "data")
           expect(ex.keys).to match([:req1, :req2, :exc3, :least1, :least2, :most2])
         end
       end
@@ -1150,10 +1150,10 @@ describe Attributor::Hash do
     let(:hash_of_strings) { Attributor::Hash.of(key: String) }
     let(:hash_of_symbols) { Attributor::Hash.of(key: Symbol) }
 
-    let(:merger) { hash_of_strings.load('a' => 1) }
-    let(:good_mergee) { hash_of_strings.load('b' => 2) }
-    let(:bad_mergee) { hash_of_symbols.load(c: 3) }
-    let(:result) { hash_of_strings.load('a' => 1, 'b' => 2) }
+    let(:merger) { hash_of_strings.load({'a' => 1},nil) }
+    let(:good_mergee) { hash_of_strings.load({'b' => 2},nil) }
+    let(:bad_mergee) { hash_of_symbols.load({c: 3}) }
+    let(:result) { hash_of_strings.load({'a' => 1, 'b' => 2},nil) }
 
     it 'validates that the mergee is of like type' do
       expect { merger.merge(bad_mergee) }.to raise_error(ArgumentError)

--- a/spec/types/integer_spec.rb
+++ b/spec/types/integer_spec.rb
@@ -97,7 +97,7 @@ describe Attributor::Integer do
           it "raises for the invalid range [#{min.inspect}, #{max.inspect}]" do
             opts = { options: { max: max, min: min } }
             expect do
-              type.example(nil, opts)
+              type.example(nil, **opts)
             end.to raise_error(Attributor::AttributorException, "Invalid range: [#{min.inspect}, #{max.inspect}]")
           end
         end

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -369,7 +369,7 @@ describe Attributor::Model do
     end
 
     context 'for models using the "requires" DSL' do
-      subject(:address) { Address.load(state: 'CA') }
+      subject(:address) { Address.load({state: 'CA'}) }
       its(:validate) { should_not be_empty }
       its(:validate) { should include 'Key name is required for $.' }
     end
@@ -380,8 +380,8 @@ describe Attributor::Model do
       end
 
       context 'that are both invalid' do
-        subject(:person) { Person.load(name: 'Joe', title: 'dude', okay: true) }
-        let(:address) { Address.load(name: '1 Main St', state: 'ME') }
+        subject(:person) { Person.load({name: 'Joe', title: 'dude', okay: true}) }
+        let(:address) { Address.load({name: '1 Main St', state: 'ME'}) }
         before do
           person.address = address
           address.person = person


### PR DESCRIPTION
This seems to do the trick...but the type.load signature is really ugly, which means that to pass loading a hash one needs to make sure it isn't in the last component...which is ... ugly. 
We should ponder on that...maybe this would be an opportunity to break compat and simplify things a bunch...

