### PR TITLE
.to_hash for model/structs (non-recursive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Attributor Changelog
 
 ## next
-- added support for enum's out of values in json_schema generation
+- Added .to_hash for Model/Struct, which returns a symbolized key hash (without recursing). This allows to splat instances of Model/Structs into functions that have keyword arguments.
 
 ## 6.1 (1/7/2022)
 - added support for enum's out of values in json_schema generation

--- a/lib/attributor/types/model.rb
+++ b/lib/attributor/types/model.rb
@@ -179,6 +179,11 @@ module Attributor
     ensure
       @dumping = false
     end
+
+    # This allows the splatting of these instances into method calls (top level hash conversion only)
+    def to_hash
+      @contents
+    end
   end
 
   # Override the generic way to get a value from an instance (models need to call the method)

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -523,4 +523,26 @@ describe Attributor::Model do
       expect(example.dump).to eq({})
     end
   end
+
+  context '#to_hash' do
+    let(:model_type) do
+      Class.new(Attributor::Model) do
+        attributes do
+          attribute :name, String
+          attribute :subkey do
+            attribute :id, Integer
+          end
+        end
+      end
+    end
+
+    subject { model_type.new(name: 'Praxis', subkey: { id: 1 }).to_hash }
+    it 'returns the top keys as a hash' do
+      expect(subject.keys).to eq([:name, :subkey])
+    end
+    it 'does not recurse down' do
+      expect(subject[:subkey]).to be_kind_of Attributor::Struct
+    end
+  end
+
 end


### PR DESCRIPTION
we already have a .to_h for the recursive version of things
.to_hash is the function that is called when splatting things into methods, so this is handy for splatting instances into method calls