### PR TITLE
Better inheritance and Collection [] sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## next
 - Support for loading "<digits>." strings in BigDecimal/Float types (These are formats supported by JS, Java ..)
+- Support for defining collections of types using a more terse DSL: T[]
+  - For example: Attributor::Integer[] is equivalent to Attributor::Collection.of(Attributor::Integer)
+  - It also caches these collection types when they are concrete (i.e., not constructable like Struct[], etc...)
+- Revamped the type and options inheritance (and :reference behavior) when defining attributes:
+  - The matrix of behavior is now fully defined, and all possible combinations of parameters are tested
+  - tightened up some error cases and messaging (i.e., cannot pass :reference unless there is a block, etc...)
 
 ## 6.5 (1/19/2023)
 - Fix JSON schema reporting for BigDecimal types to be a string, with a format=bigdecimal

--- a/lib/attributor/dsl_compiler.rb
+++ b/lib/attributor/dsl_compiler.rb
@@ -80,7 +80,6 @@ module Attributor
     # @api semiprivate
     def define(name, attr_type = nil, **opts, &block)
       example_given = opts.key? :example
-
       # add to existing attribute if present
       if (existing_attribute = attributes[name])
         if existing_attribute.attributes
@@ -88,67 +87,39 @@ module Attributor
           return existing_attribute
         end
       end
+    
+      if attr_type.nil?
+        if block_given?
+          final_type, carried_options = resolveTypeForBlock(name,  **opts, &block)
+        else
+          final_type, carried_options = resolveTypeForNoBlock(name,  **opts)
+        end
+      else
+        final_type = attr_type
+        carried_options = {}
+      end
+
+      final_opts = opts.dup
+      final_opts.delete(:reference) 
       
-      res = origdefine(name, attr_type, **opts, &block)
-      # puts "DEFINED: #{name} (t: #{attr_type}) as #{res[0]} and options:\n#{res[1]}"
-      Attributor::Attribute.new(res[0], res[1], &block)
+      # Possibly add a reference for block definitions (No reference for leaves)
+      final_opts.merge!(addReferenceToBlock(name, opts)) if block_given?
+      final_opts = carried_options.merge(final_opts)
+      Attributor::Attribute.new(final_type, final_opts, &block)
     end
 
-    def good_explanation_about_redefining_already_defined_types(name, ref, type_from_ref, &block)
-      existing_type_name = type_from_ref < Attributor::Collection ? "Collection.of(#{type_from_ref.member_attribute.type})" : type_from_ref.to_s
-      location_file, location_line = block.source_location
-      message = "Invalid redefinition of attributes for an already existing type:\n"
-      message += "Existing type Type #{existing_type_name} cannot be further redefined with the block you are providing.\n"
-      message += "You are getting this because you are not specifying an explicit type for your '#{name}' attribute, and therefore"
-      message += "the framework is trying to inherit the type from the passed :reference option in the enclosing block. This :reference "
-      message += "is pointing to type: #{ref}, which also has an attribute named '#{name}' with type #{existing_type_name}, that matches"
-      message += "the name of the attribute you are trying to define in here:\n#{location_file} line #{location_line}\n#{block.source}\n"
-      message += "It is likely that you either want to explictly set the type to a Struct (or Collection.of(Struct)) and redefine that in your block"
-      message += "or perhaps you want to 'refine/change' the attributes of #{ref} within your block, in which case what you should do is to"
-      message += "explicitly set the type to a Struct (or Collection.of(Struct)) and then use the :reference option to point to #{ref}.\n"
-      raise message
-    end
-    def resolveTypeForBlock(name,  **opts, &block)
+
+    def resolveTypeForBlock(name,  **opts)
       resolved_type = nil
       carried_options = {}
       ref = options[:reference]
-      if ref
-        if ref.respond_to?(:attributes) && ref.attributes.key?(name)
-          type_from_ref = ref.attributes[name]&.type
-
-          resolved_type = type_from_ref < Attributor::Collection ? Attributor::Struct[] : Attributor::Struct
-
-          # unless type_from_ref == Attributor::Struct || type_from_ref == Attributor::Collection.of(Attributor::Struct)
-          #   good_explanation_about_redefining_already_defined_types(name, ref, type_from_ref, &block)
-          # end
-          # resolved_type = type_from_ref # Return the raw, and anonymous type Struct or Attributor::Collection.of(Attributor::Struct)
-
-          # TODO: We could default to Struct[] if we see the reference is a Collection ...
-          # resolved_type = Attributor::Struct
-          #carried_options = ref.attributes[name].options # Somehow bring any options from the type?
-        else
-          puts "WARNING: Type for attribute with name: #{name} could not be determined from reference: #{ref}...defaulting to Struct"
-          resolved_type = Attributor::Struct
-          
-          # message = "Type for attribute with name: #{name} could not be determined.\n"
-          # if ref
-          #   message += "You are defining '#{name}' without a type, and the passed in :reference type (#{ref}) does not have an attribute named '#{name}'.\n" \
-          # else
-          #   message += "You are defining '#{name}' without a type, and there is no :reference type to infer it from (Did you forget to add the type?).\n" \
-          # end
-          # location_file, location_line = block.source_location
-          # message += "\nIf you are omiting a type, thinking that would be inherited from the reference, make sure the right one is passed in," \
-          #   ",add the missing attribute to the reference type or simply add the right missing type in the attribute definition otherwise.\n"
-          #   "If you are omiting it to imply it is a Struct, please explicitly add it in the attribute definition (or add the right missing type otherwise)\n"
-          # message += "This is the definition block where the issue was found:\n#{location_file} line #{location_line}\n#{block.source}"
-          # require 'pry'
-          # binding.pry
-          # raise AttributorException, message
-        end
+      if ref && ref.respond_to?(:attributes) && ref.attributes.key?(name)
+        type_from_ref = ref.attributes[name]&.type
+        resolved_type = type_from_ref < Attributor::Collection ? Attributor::Struct[] : Attributor::Struct
       else
+        # Type for attribute with given name could not be determined from reference...or ther is not refrence: defaulting to Struct"
         resolved_type = Attributor::Struct
       end
-      # TODO: We could also default to Struct if there is a reference, but does not have the attribute ....
       [resolved_type, carried_options]
     end
 
@@ -160,19 +131,14 @@ module Attributor
         resolved_type = ref.attributes[name].type
         carried_options = ref.attributes[name].options
       else
-        # require 'pry'
-        # binding.pry
         message = "Type for attribute with name: #{name} could not be determined.\n"
-          # if ref
-          #   message += "You are defining '#{name}' without a type, and the passed in :reference type (#{ref}) does not have an attribute named '#{name}'.\n" \
-          # else
-          #   message += "You are defining '#{name}' without a type, and there is no :reference type to infer it from (Did you forget to add the type?).\n" \
-          # end
-          # location_file, location_line = block.source_location
-          # message += "\nIf you are omiting a type, thinking that would be inherited from the reference, make sure the right one is passed in," \
-          #   ",add the missing attribute to the reference type or simply add the right missing type in the attribute definition otherwise.\n"
-          #   "If you are omiting it to imply it is a Struct, please explicitly add it in the attribute definition (or add the right missing type otherwise)\n"
-          # message += "This is the definition block where the issue was found:\n#{location_file} line #{location_line}\n#{block.source}"
+        if ref
+          message += "You are defining '#{name}' without a type, and the passed in :reference type (#{ref}) does not have an attribute named '#{name}'.\n" \
+        else
+          message += "You are defining '#{name}' without a type, and there is no :reference type to infer it from (Did you forget to add the type?).\n" \
+        end
+        message += "\nIf you are omiting a type thinking that would be inherited from the reference, make sure the right one is passed in," \
+          ", which has a #{name} defined, otherwise simply specify the type of the attribute you want.\n"
         raise AttributorException, message
       end
       [resolved_type, carried_options]
@@ -189,210 +155,6 @@ module Attributor
       else
         {}
       end
-    end
-
-    def origdefine(name, attr_type = nil, **opts, &block)
-      example_given = opts.key? :example
-      # add to existing attribute if present
-      if (existing_attribute = attributes[name])
-        if existing_attribute.attributes
-          existing_attribute.type.attributes(&block)
-          return existing_attribute
-        end
-      end
-
-      if attr_type.nil?
-        if block_given?
-          # if(name == :neighbors)
-          #   require 'pry'
-          #   binding.pry
-          #   require 'pry'
-          #   binding.pry
-          # end
-          final_type, carried_options = resolveTypeForBlock(name,  **opts, &block)
-        else
-          final_type, carried_options = resolveTypeForNoBlock(name,  **opts)
-        end
-      else
-        final_type = attr_type
-        carried_options = {}
-      end
-
-      
-      final_opts = opts.dup
-      final_opts.delete(:reference) 
-      if block_given?
-        final_opts.merge!(addReferenceToBlock(name, opts))
-      else
-        # No reference for leaves
-      end
-      # TODO: Need to percolate incoming ops as well...
-      final_opts = carried_options.merge(final_opts)
-
-      # puts "DEFINING: #{name} with type #{attr_type} and opts #{opts} (DSL Opts: #{options})"
-      # puts "-----   : resolved to: #{final_type} and opts #{final_opts}"
-
-      return [final_type, final_opts]
-      ##############################
-      # determine inherited type (giving preference to the direct attribute options)
-      type_from_ref = opts[:reference]
-      unless type_from_ref
-        reference = options[:reference]
-        if reference && reference.respond_to?(:attributes) && reference.attributes.key?(name)
-          inherited_attribute = reference.attributes[name]
-          
-          if block_given?
-            type_from_ref = inherited_attribute.type
-            opts[:reference] = type_from_ref # We pass it down in case, but the block might completely redefine it
-          else
-            opts = inherited_attribute.options.merge(opts) unless attr_type #?? why unless?            
-          end
-        end
-      end
-
-      # determine attribute type to use
-      if attr_type.nil?
-        if block_given?
-          # Don't inherit explicit examples if we've redefined the structure 
-          # (but preserve the direct example if given here)
-          opts.delete :example unless  example_given
-          attr_type = if type_from_ref && type_from_ref < Attributor::Collection
-                        # override the reference to be the member_attribute's type for collections
-                        opts[:reference] = type_from_ref.member_attribute.type
-                        Attributor::Collection.of(Struct)
-                      else
-                        Attributor::Struct
-                      end
-        elsif type_from_ref
-          attr_type = type_from_ref
-        else
-          require 'pry'
-          binding.pry
-          raise AttributorException, "type for attribute with name: #{name} could not be determined!"
-        end
-      end
-      [attr_type, opts]
-    end
-    def newdefine(name,  attr_type = nil, **opts, &block)
-      ref = opts[:reference] || options[:reference]
-      # puts "DEFINING: #{name} with type #{attr_type} and opts #{opts} (DSL Opts: #{options})=> ref: #{ref}"
-
-      if attr_type.nil?
-        if block_given?
-          if ref
-            if ref.respond_to?(:attributes) && ref.attributes.key?(name)
-              inherited_attribute = ref.attributes[name]
-              inherited_type = inherited_attribute.type
-              final_type = inherited_type < Attributor::Collection ?  Attributor::Collection.of(Attributor::Struct) : Attributor::Struct
-              if inherited_type < Attributor::Collection
-                opts = inherited_attribute.options.merge(opts)
-                # override the reference to be the member_attribute's type for collections
-                inherited_type = inherited_type.member_attribute.type
-              elsif inherited_type < Attributor::Model # Allow it to be a model, not just a struct
-                opts = inherited_attribute.options.merge(opts) # Merge all options if reference is a Struct
-              end
-              opts[:reference] = inherited_type  if inherited_type # Pass reference if any
-            end
-          else
-            # No type and no reference, it's a 'blank' Struct by default (since there's a block given), best we can do
-            # Note: cannot try to define a Collection of Struct here, since we don't know the type of the collection
-            final_type = Attributor::Struct
-          end
-          # The reference is for the block attributes...if we don't have one (and don't have a type, we cannot really guess it)
-          # if ref.nil?
-          #   if ref && ref.respond_to?(:attributes) && ref.attributes.key?(name)
-          #     inherited_attribute = ref.attributes[name]
-          #     inherited_type = inherited_attribute.type
-          #     final_type = inherited_type < Attributor::Collection ?  Attributor::Collection.of(Attributor::Struct) : Attributor::Struct
-          #     if inherited_type && inherited_type < Attributor::Collection
-          #       opts = inherited_attribute.options.merge(opts)
-          #       # override the reference to be the member_attribute's type for collections
-          #       inherited_type = inherited_type.member_attribute.type
-          #     elsif inherited_type < Attributor::Model # Allow it to be a model, not just a struct
-          #       opts = inherited_attribute.options.merge(opts) # Merge all options if reference is a Struct
-          #     end
-          #     opts[:reference] = inherited_type  if inherited_type # Pass reference if any
-          #   else
-          #     opts[:reference] = ref # Could be rewriting the already existing one in ops, or use the one in options...
-          #   end
-          # end
-          opts[:reference] = ref # Could be rewriting the already existing one in ops, or use the one in options...
-          # If there's no type and no reference, it's a Struct by default (since there's a block given)
-          final_type = final_type || Attributor::Struct
-        else
-          # Do not pass reference even if there's one
-          if ref
-            resolved_ref =  ref < Attributor::Collection ? ref.member_attribute.type : ref
-            if resolved_ref.respond_to?(:attributes) && resolved_ref.attributes.key?(name)
-              inherited_attribute = resolved_ref.attributes[name]
-              final_type = inherited_attribute.type # Find the ref type
-              opts = inherited_attribute.options.merge(opts) # Merge all options
-            end
-          end
-        end
-      else
-        if block_given?
-          # if ref && ref.respond_to?(:attributes) && ref.attributes.key?(name)
-          #   inherited_attribute = ref.attributes[name]
-          #   inherited_type = inherited_attribute.type
-          #   if inherited_type && inherited_type < Attributor::Collection
-          #     # override the reference to be the member_attribute's type for collections
-          #     opts[:reference] = inherited_type.member_attribute.type
-          #   else
-          #     opts[:reference] = inherited_type
-          #   end  
-          #   opts = inherited_attribute.options.merge(opts) # Merge all options
-          # end
-          # NEED TO PASS A REFERENCE IF THERE's A TYPE? or should be look it up?
-          final_type = attr_type
-        else
-          if ref && ref.respond_to?(:attributes) && ref.attributes.key?(name)
-            inherited_attribute = ref.attributes[name]
-            opts = inherited_attribute.options.merge(opts) # Merge all options
-          end
-          final_type = attr_type
-        end
-      end
-      # # determine inherited type (giving preference to the direct attribute options)
-      # inherited_type = opts[:reference]
-      # unless inherited_type
-      #   reference = options[:reference]
-      #   if reference && reference.respond_to?(:attributes) && reference.attributes.key?(name)
-      #     inherited_attribute = reference.attributes[name]
-      #     unless attr_type
-      #       inherited_type = inherited_attribute.type
-      #       opts[:reference] = inherited_type if block_given?
-  
-      #       if inherited_type < Attributor::Collection || inherited_type < Attributor::Hash
-      #         opts = inherited_attribute.options.merge(opts) 
-      #       end
-      #     end
-      #   end
-      # end
-
-      # # determine attribute type to use
-      # if attr_type.nil?
-      #   if block_given?
-      #     # Don't inherit explicit examples if we've redefined the structure 
-      #     # (but preserve the direct example if given here)
-      #     opts.delete :example unless  example_given
-      #     attr_type = if inherited_type && inherited_type < Attributor::Collection
-      #                   # override the reference to be the member_attribute's type for collections
-      #                   opts[:reference] = inherited_type.member_attribute.type
-      #                   Attributor::Collection.of(Struct)
-      #                 else
-      #                   Attributor::Struct
-      #                 end
-      #   elsif inherited_type
-      #     attr_type = inherited_type
-      #   else
-      #     raise AttributorException, "type for attribute with name: #{name} could not be determined"
-      #   end
-      # end
-        
-      raise AttributorException, "type for attribute with name: #{name} could not be determined" unless final_type
-
-      [final_type, opts]
     end
   end
 end

--- a/lib/attributor/dsl_compiler.rb
+++ b/lib/attributor/dsl_compiler.rb
@@ -33,7 +33,16 @@ module Attributor
 
     def attribute(name, attr_type = nil, **opts, &block)
       raise AttributorException, "Attribute names must be symbols, got: #{name.inspect}" unless name.is_a? ::Symbol
-      raise AttributorException, ":reference option can only be used when defining blocks" if opts[:reference] && !block_given? 
+      if opts[:reference]
+        raise AttributorException, ":reference option can only be used when defining blocks"  unless block_given? 
+        if opts[:reference] < Attributor::Collection
+          err = ":reference option cannot be a collection. It must be a concrete type of Struct-like type where to look up the type"
+               "for the attribute #{name} you are defining"
+          location_file, location_line = block.source_location               
+          err += "The place where you are trying to define the attribute is here:\n#{location_file} line #{location_line}\n#{block.source}\n"
+          raise AttributorException, err
+        end
+      end
       target.attributes[name] = define(name, attr_type, **opts, &block)
     end
 

--- a/lib/attributor/dsl_compiler.rb
+++ b/lib/attributor/dsl_compiler.rb
@@ -115,11 +115,17 @@ module Attributor
       if ref
         if ref.respond_to?(:attributes) && ref.attributes.key?(name)
           type_from_ref = ref.attributes[name]&.type
-          unless type_from_ref == Attributor::Struct || type_from_ref == Attributor::Collection.of(Attributor::Struct)
-            good_explanation_about_redefining_already_defined_types(name, ref, type_from_ref, &block)
-          end
-          resolved_type = type_from_ref # Return the raw, and anonymous type Struct or Attributor::Collection.of(Attributor::Struct)
-          carried_options = ref.attributes[name].options # Somehow bring any options from the anonymous type 
+
+          resolved_type = type_from_ref < Attributor::Collection ? Attributor::Struct[] : Attributor::Struct
+
+          # unless type_from_ref == Attributor::Struct || type_from_ref == Attributor::Collection.of(Attributor::Struct)
+          #   good_explanation_about_redefining_already_defined_types(name, ref, type_from_ref, &block)
+          # end
+          # resolved_type = type_from_ref # Return the raw, and anonymous type Struct or Attributor::Collection.of(Attributor::Struct)
+
+          # TODO: We could default to Struct[] if we see the reference is a Collection ...
+          # resolved_type = Attributor::Struct
+          #carried_options = ref.attributes[name].options # Somehow bring any options from the type?
         else
           puts "WARNING: Type for attribute with name: #{name} could not be determined from reference: #{ref}...defaulting to Struct"
           resolved_type = Attributor::Struct

--- a/lib/attributor/dsl_compiler.rb
+++ b/lib/attributor/dsl_compiler.rb
@@ -33,6 +33,7 @@ module Attributor
 
     def attribute(name, attr_type = nil, **opts, &block)
       raise AttributorException, "Attribute names must be symbols, got: #{name.inspect}" unless name.is_a? ::Symbol
+      raise AttributorException, ":reference option can only be used when defining blocks" if opts[:reference] && !block_given? 
       target.attributes[name] = define(name, attr_type, **opts, &block)
     end
 
@@ -87,16 +88,159 @@ module Attributor
           return existing_attribute
         end
       end
+      
+      res = origdefine(name, attr_type, **opts, &block)
+      # puts "DEFINED: #{name} (t: #{attr_type}) as #{res[0]} and options:\n#{res[1]}"
+      Attributor::Attribute.new(res[0], res[1], &block)
+    end
 
+    def good_explanation_about_redefining_already_defined_types(name, ref, type_from_ref, &block)
+      existing_type_name = type_from_ref < Attributor::Collection ? "Collection.of(#{type_from_ref.member_attribute.type})" : type_from_ref.to_s
+      location_file, location_line = block.source_location
+      message = "Invalid redefinition of attributes for an already existing type:\n"
+      message += "Existing type Type #{existing_type_name} cannot be further redefined with the block you are providing.\n"
+      message += "You are getting this because you are not specifying an explicit type for your '#{name}' attribute, and therefore"
+      message += "the framework is trying to inherit the type from the passed :reference option in the enclosing block. This :reference "
+      message += "is pointing to type: #{ref}, which also has an attribute named '#{name}' with type #{existing_type_name}, that matches"
+      message += "the name of the attribute you are trying to define in here:\n#{location_file} line #{location_line}\n#{block.source}\n"
+      message += "It is likely that you either want to explictly set the type to a Struct (or Collection.of(Struct)) and redefine that in your block"
+      message += "or perhaps you want to 'refine/change' the attributes of #{ref} within your block, in which case what you should do is to"
+      message += "explicitly set the type to a Struct (or Collection.of(Struct)) and then use the :reference option to point to #{ref}.\n"
+      raise message
+    end
+    def resolveTypeForBlock(name,  **opts, &block)
+      resolved_type = nil
+      carried_options = {}
+      ref = options[:reference]
+      if ref
+        if ref.respond_to?(:attributes) && ref.attributes.key?(name)
+          type_from_ref = ref.attributes[name]&.type
+          unless type_from_ref == Attributor::Struct || type_from_ref == Attributor::Collection.of(Attributor::Struct)
+            good_explanation_about_redefining_already_defined_types(name, ref, type_from_ref, &block)
+          end
+          resolved_type = type_from_ref # Return the raw, and anonymous type Struct or Attributor::Collection.of(Attributor::Struct)
+          carried_options = ref.attributes[name].options # Somehow bring any options from the anonymous type 
+        else
+          puts "WARNING: Type for attribute with name: #{name} could not be determined from reference: #{ref}...defaulting to Struct"
+          resolved_type = Attributor::Struct
+          
+          # message = "Type for attribute with name: #{name} could not be determined.\n"
+          # if ref
+          #   message += "You are defining '#{name}' without a type, and the passed in :reference type (#{ref}) does not have an attribute named '#{name}'.\n" \
+          # else
+          #   message += "You are defining '#{name}' without a type, and there is no :reference type to infer it from (Did you forget to add the type?).\n" \
+          # end
+          # location_file, location_line = block.source_location
+          # message += "\nIf you are omiting a type, thinking that would be inherited from the reference, make sure the right one is passed in," \
+          #   ",add the missing attribute to the reference type or simply add the right missing type in the attribute definition otherwise.\n"
+          #   "If you are omiting it to imply it is a Struct, please explicitly add it in the attribute definition (or add the right missing type otherwise)\n"
+          # message += "This is the definition block where the issue was found:\n#{location_file} line #{location_line}\n#{block.source}"
+          # require 'pry'
+          # binding.pry
+          # raise AttributorException, message
+        end
+      else
+        resolved_type = Attributor::Struct
+      end
+      # TODO: We could also default to Struct if there is a reference, but does not have the attribute ....
+      [resolved_type, carried_options]
+    end
+
+    def resolveTypeForNoBlock(name,  **opts)
+      resolved_type = nil
+      carried_options = {}
+      ref = options[:reference]
+      if ref && ref.respond_to?(:attributes) && ref.attributes.key?(name)
+        resolved_type = ref.attributes[name].type
+        carried_options = ref.attributes[name].options
+      else
+        # require 'pry'
+        # binding.pry
+        message = "Type for attribute with name: #{name} could not be determined.\n"
+          # if ref
+          #   message += "You are defining '#{name}' without a type, and the passed in :reference type (#{ref}) does not have an attribute named '#{name}'.\n" \
+          # else
+          #   message += "You are defining '#{name}' without a type, and there is no :reference type to infer it from (Did you forget to add the type?).\n" \
+          # end
+          # location_file, location_line = block.source_location
+          # message += "\nIf you are omiting a type, thinking that would be inherited from the reference, make sure the right one is passed in," \
+          #   ",add the missing attribute to the reference type or simply add the right missing type in the attribute definition otherwise.\n"
+          #   "If you are omiting it to imply it is a Struct, please explicitly add it in the attribute definition (or add the right missing type otherwise)\n"
+          # message += "This is the definition block where the issue was found:\n#{location_file} line #{location_line}\n#{block.source}"
+        raise AttributorException, message
+      end
+      [resolved_type, carried_options]
+    end
+
+    def addReferenceToBlock(name, opts)
+      base_reference  = options[:reference]
+      if opts[:reference] # Direct reference specified in the attribute, just pass it to the block
+        {reference: opts[:reference]}
+      elsif( base_reference && base_reference.respond_to?(:attributes) && base_reference.attributes.key?(name))
+        selected_type = base_reference.attributes[name].type
+        selected_type = selected_type.member_attribute.type if selected_type < Attributor::Collection
+        {reference: selected_type}
+      else
+        {}
+      end
+    end
+
+    def origdefine(name, attr_type = nil, **opts, &block)
+      example_given = opts.key? :example
+      # add to existing attribute if present
+      if (existing_attribute = attributes[name])
+        if existing_attribute.attributes
+          existing_attribute.type.attributes(&block)
+          return existing_attribute
+        end
+      end
+
+      if attr_type.nil?
+        if block_given?
+          # if(name == :neighbors)
+          #   require 'pry'
+          #   binding.pry
+          #   require 'pry'
+          #   binding.pry
+          # end
+          final_type, carried_options = resolveTypeForBlock(name,  **opts, &block)
+        else
+          final_type, carried_options = resolveTypeForNoBlock(name,  **opts)
+        end
+      else
+        final_type = attr_type
+        carried_options = {}
+      end
+
+      
+      final_opts = opts.dup
+      final_opts.delete(:reference) 
+      if block_given?
+        final_opts.merge!(addReferenceToBlock(name, opts))
+      else
+        # No reference for leaves
+      end
+      # TODO: Need to percolate incoming ops as well...
+      final_opts = carried_options.merge(final_opts)
+
+      # puts "DEFINING: #{name} with type #{attr_type} and opts #{opts} (DSL Opts: #{options})"
+      # puts "-----   : resolved to: #{final_type} and opts #{final_opts}"
+
+      return [final_type, final_opts]
+      ##############################
       # determine inherited type (giving preference to the direct attribute options)
-      inherited_type = opts[:reference]
-      unless inherited_type
+      type_from_ref = opts[:reference]
+      unless type_from_ref
         reference = options[:reference]
         if reference && reference.respond_to?(:attributes) && reference.attributes.key?(name)
           inherited_attribute = reference.attributes[name]
-          opts = inherited_attribute.options.merge(opts) unless attr_type
-          inherited_type = inherited_attribute.type
-          opts[:reference] = inherited_type if block_given?
+          
+          if block_given?
+            type_from_ref = inherited_attribute.type
+            opts[:reference] = type_from_ref # We pass it down in case, but the block might completely redefine it
+          else
+            opts = inherited_attribute.options.merge(opts) unless attr_type #?? why unless?            
+          end
         end
       end
 
@@ -106,21 +250,143 @@ module Attributor
           # Don't inherit explicit examples if we've redefined the structure 
           # (but preserve the direct example if given here)
           opts.delete :example unless  example_given
-          attr_type = if inherited_type && inherited_type < Attributor::Collection
+          attr_type = if type_from_ref && type_from_ref < Attributor::Collection
                         # override the reference to be the member_attribute's type for collections
-                        opts[:reference] = inherited_type.member_attribute.type
+                        opts[:reference] = type_from_ref.member_attribute.type
                         Attributor::Collection.of(Struct)
                       else
                         Attributor::Struct
                       end
-        elsif inherited_type
-          attr_type = inherited_type
+        elsif type_from_ref
+          attr_type = type_from_ref
         else
-          raise AttributorException, "type for attribute with name: #{name} could not be determined"
+          require 'pry'
+          binding.pry
+          raise AttributorException, "type for attribute with name: #{name} could not be determined!"
         end
       end
+      [attr_type, opts]
+    end
+    def newdefine(name,  attr_type = nil, **opts, &block)
+      ref = opts[:reference] || options[:reference]
+      # puts "DEFINING: #{name} with type #{attr_type} and opts #{opts} (DSL Opts: #{options})=> ref: #{ref}"
 
-      Attributor::Attribute.new(attr_type, opts, &block)
+      if attr_type.nil?
+        if block_given?
+          if ref
+            if ref.respond_to?(:attributes) && ref.attributes.key?(name)
+              inherited_attribute = ref.attributes[name]
+              inherited_type = inherited_attribute.type
+              final_type = inherited_type < Attributor::Collection ?  Attributor::Collection.of(Attributor::Struct) : Attributor::Struct
+              if inherited_type < Attributor::Collection
+                opts = inherited_attribute.options.merge(opts)
+                # override the reference to be the member_attribute's type for collections
+                inherited_type = inherited_type.member_attribute.type
+              elsif inherited_type < Attributor::Model # Allow it to be a model, not just a struct
+                opts = inherited_attribute.options.merge(opts) # Merge all options if reference is a Struct
+              end
+              opts[:reference] = inherited_type  if inherited_type # Pass reference if any
+            end
+          else
+            # No type and no reference, it's a 'blank' Struct by default (since there's a block given), best we can do
+            # Note: cannot try to define a Collection of Struct here, since we don't know the type of the collection
+            final_type = Attributor::Struct
+          end
+          # The reference is for the block attributes...if we don't have one (and don't have a type, we cannot really guess it)
+          # if ref.nil?
+          #   if ref && ref.respond_to?(:attributes) && ref.attributes.key?(name)
+          #     inherited_attribute = ref.attributes[name]
+          #     inherited_type = inherited_attribute.type
+          #     final_type = inherited_type < Attributor::Collection ?  Attributor::Collection.of(Attributor::Struct) : Attributor::Struct
+          #     if inherited_type && inherited_type < Attributor::Collection
+          #       opts = inherited_attribute.options.merge(opts)
+          #       # override the reference to be the member_attribute's type for collections
+          #       inherited_type = inherited_type.member_attribute.type
+          #     elsif inherited_type < Attributor::Model # Allow it to be a model, not just a struct
+          #       opts = inherited_attribute.options.merge(opts) # Merge all options if reference is a Struct
+          #     end
+          #     opts[:reference] = inherited_type  if inherited_type # Pass reference if any
+          #   else
+          #     opts[:reference] = ref # Could be rewriting the already existing one in ops, or use the one in options...
+          #   end
+          # end
+          opts[:reference] = ref # Could be rewriting the already existing one in ops, or use the one in options...
+          # If there's no type and no reference, it's a Struct by default (since there's a block given)
+          final_type = final_type || Attributor::Struct
+        else
+          # Do not pass reference even if there's one
+          if ref
+            resolved_ref =  ref < Attributor::Collection ? ref.member_attribute.type : ref
+            if resolved_ref.respond_to?(:attributes) && resolved_ref.attributes.key?(name)
+              inherited_attribute = resolved_ref.attributes[name]
+              final_type = inherited_attribute.type # Find the ref type
+              opts = inherited_attribute.options.merge(opts) # Merge all options
+            end
+          end
+        end
+      else
+        if block_given?
+          # if ref && ref.respond_to?(:attributes) && ref.attributes.key?(name)
+          #   inherited_attribute = ref.attributes[name]
+          #   inherited_type = inherited_attribute.type
+          #   if inherited_type && inherited_type < Attributor::Collection
+          #     # override the reference to be the member_attribute's type for collections
+          #     opts[:reference] = inherited_type.member_attribute.type
+          #   else
+          #     opts[:reference] = inherited_type
+          #   end  
+          #   opts = inherited_attribute.options.merge(opts) # Merge all options
+          # end
+          # NEED TO PASS A REFERENCE IF THERE's A TYPE? or should be look it up?
+          final_type = attr_type
+        else
+          if ref && ref.respond_to?(:attributes) && ref.attributes.key?(name)
+            inherited_attribute = ref.attributes[name]
+            opts = inherited_attribute.options.merge(opts) # Merge all options
+          end
+          final_type = attr_type
+        end
+      end
+      # # determine inherited type (giving preference to the direct attribute options)
+      # inherited_type = opts[:reference]
+      # unless inherited_type
+      #   reference = options[:reference]
+      #   if reference && reference.respond_to?(:attributes) && reference.attributes.key?(name)
+      #     inherited_attribute = reference.attributes[name]
+      #     unless attr_type
+      #       inherited_type = inherited_attribute.type
+      #       opts[:reference] = inherited_type if block_given?
+  
+      #       if inherited_type < Attributor::Collection || inherited_type < Attributor::Hash
+      #         opts = inherited_attribute.options.merge(opts) 
+      #       end
+      #     end
+      #   end
+      # end
+
+      # # determine attribute type to use
+      # if attr_type.nil?
+      #   if block_given?
+      #     # Don't inherit explicit examples if we've redefined the structure 
+      #     # (but preserve the direct example if given here)
+      #     opts.delete :example unless  example_given
+      #     attr_type = if inherited_type && inherited_type < Attributor::Collection
+      #                   # override the reference to be the member_attribute's type for collections
+      #                   opts[:reference] = inherited_type.member_attribute.type
+      #                   Attributor::Collection.of(Struct)
+      #                 else
+      #                   Attributor::Struct
+      #                 end
+      #   elsif inherited_type
+      #     attr_type = inherited_type
+      #   else
+      #     raise AttributorException, "type for attribute with name: #{name} could not be determined"
+      #   end
+      # end
+        
+      raise AttributorException, "type for attribute with name: #{name} could not be determined" unless final_type
+
+      [final_type, opts]
     end
   end
 end

--- a/lib/attributor/type.rb
+++ b/lib/attributor/type.rb
@@ -4,6 +4,11 @@ module Attributor
   module Type
     extend ActiveSupport::Concern
 
+    included do
+      def self.[]
+        ::Attributor::Collection.of(self)
+      end
+    end
     module ClassMethods
       # Does this type support the generation of subtypes?
       def constructable?

--- a/lib/attributor/type.rb
+++ b/lib/attributor/type.rb
@@ -24,9 +24,8 @@ module Attributor
       class << self
         attr_accessor :_memoized_collection_classes
         def get_memoized_collection_class(member_class, collection_type=Attributor::Collection)
-          @_memoized_collection_classes_mutex.synchronize do
-            _memoized_collection_classes.dig(member_class,collection_type)
-          end
+          # No need to serialize on read, Ruby will ensure we can properly read what's there, even if it's being written
+          _memoized_collection_classes.dig(member_class,collection_type)
         end
         def set_memoized_collection_class(klass, member_class, collection_type=Attributor::Collection)
           @_memoized_collection_classes_mutex.synchronize do

--- a/lib/attributor/type.rb
+++ b/lib/attributor/type.rb
@@ -149,7 +149,9 @@ module Attributor
           option_value  # By default, describing an option returns the hash with the specification
         end
       end
-
+      def options
+        {}
+      end
     end
   end
 end

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -12,13 +12,9 @@ module Attributor
     # @example Collection.of(Integer)
     #
     def self.of(type)
+      # Favor T[] since that even caches the non-construcable types
       resolved_type = Attributor.resolve_type(type)
-      unless resolved_type.ancestors.include?(Attributor::Type)
-        raise Attributor::AttributorException, 'Collections can only have members that are Attributor::Types'
-      end
-      ::Class.new(self) do
-        @member_type = resolved_type
-      end
+      resolved_type[]
     end
 
     @options = {}

--- a/lib/attributor/types/collection.rb
+++ b/lib/attributor/types/collection.rb
@@ -14,7 +14,7 @@ module Attributor
     def self.of(type)
       # Favor T[] since that even caches the non-construcable types
       resolved_type = Attributor.resolve_type(type)
-      resolved_type[]
+      resolved_type[self]
     end
 
     @options = {}

--- a/lib/attributor/types/struct.rb
+++ b/lib/attributor/types/struct.rb
@@ -7,14 +7,19 @@ module Attributor
 
     # Construct a new subclass, using attribute_definition to define attributes.
     def self.construct(attribute_definition, options = {})
-      # if we're in a subclass of Struct, but not attribute_definition is provided, we're
+      # if we're in a subclass of Struct, but no attribute_definition is provided, we're
       # not REALLY trying to define a new struct. more than likely Collection is calling
       # construct on us.
       unless self == Attributor::Struct || attribute_definition.nil?
-        raise AttributorException, "can not construct from already-constructed Struct: #{self}"
-        # TODO: give a good explanation of what this means (a full type cannot take a block to redefine)...and the fact
-        # that only a Struct (or collection of Struct) can do that...and the fact that this might be due to not having
-        # a type in the definition, and the fact that the full type might be inherited...so perhaps you forgot to add Struct/Collection(Struct) to it
+        location_file, location_line = attribute_definition.source_location
+        message = "You cannot change an already defined Struct type:\n"
+        message += "It seems you are trying to define attributes, using a block, on top of an existing concrete Struct type that already has been fully defined.\n"
+        message += "The place where you are trying to define the type is here:\n#{location_file} line #{location_line}\n#{attribute_definition.source}\n"
+        message += "If what you meant was to define a brand new Struct or Struct[], please make sure you pass the type in the attribute definition,\n"
+        message += "rather than leaving it blank.\n"
+        message += "Otherwise, what might be happening is that you have left out the explicit type, and the framework has inferred it from the"
+        message += "corresponding :reference type attribute (and hence running into the conflict of trying to redefine an existing type)."
+        raise AttributorException, message
       end
 
       # TODO: massage the options here to pull out only the relevant ones

--- a/lib/attributor/types/struct.rb
+++ b/lib/attributor/types/struct.rb
@@ -11,7 +11,10 @@ module Attributor
       # not REALLY trying to define a new struct. more than likely Collection is calling
       # construct on us.
       unless self == Attributor::Struct || attribute_definition.nil?
-        raise AttributorException, 'can not construct from already-constructed Struct'
+        raise AttributorException, "can not construct from already-constructed Struct: #{self}"
+        # TODO: give a good explanation of what this means (a full type cannot take a block to redefine)...and the fact
+        # that only a Struct (or collection of Struct) can do that...and the fact that this might be due to not having
+        # a type in the definition, and the fact that the full type might be inherited...so perhaps you forgot to add Struct/Collection(Struct) to it
       end
 
       # TODO: massage the options here to pull out only the relevant ones

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -323,7 +323,7 @@ describe Attributor::Attribute do
     end
 
     context 'with a regexp' do
-      let(:example) { /\w+/ }
+      let(:example) { Regexp.new(/\w+/) }
       let(:generated_example) { /\w+/.gen }
 
       it 'calls #gen on the regexp' do
@@ -334,7 +334,7 @@ describe Attributor::Attribute do
 
       context 'for a type with a non-String native_type' do
         let(:type) { Attributor::Integer }
-        let(:example) { /\d{5}/ }
+        let(:example) { Regexp.new(/\d{5}/) }
         let(:generated_example) { /\d{5}/.gen }
 
         it 'coerces the example value properly' do

--- a/spec/dsl_compiler_spec.rb
+++ b/spec/dsl_compiler_spec.rb
@@ -38,7 +38,6 @@ describe Attributor::DSLCompiler do
           dsl_compiler.attribute(attribute_name, type, **attribute_options)
         end
       end
-
       context 'with a reference' do
         let(:dsl_compiler_options) { { reference: Turducken } }
 
@@ -126,6 +125,7 @@ describe Attributor::DSLCompiler do
       end
     end
   end
+
   context 'type resolution, option inheritance for attributes with and without references' do
     # Overall strategy
     # 1) When no type is specified:
@@ -340,13 +340,13 @@ describe Attributor::DSLCompiler do
       context 'always uses the type and options specified ignoring any reference if there is one' do
       end
     end
-    context 'no reference no type for leaf => error' do
+    context 'no reference no type for leaf' do
       let(:myblock) { Proc.new do
         attributes do
           attribute :name
         end
       end }
-      it 'works' do
+      it 'fails as it is not possible to resolve what type to use ' do
         expect{mytype.attributes}.to raise_error(/Type for attribute with name: name could not be determined./)
       end
     end

--- a/spec/dsl_compiler_spec.rb
+++ b/spec/dsl_compiler_spec.rb
@@ -25,7 +25,7 @@ describe Attributor::DSLCompiler do
         it 'raises an error for a missing type' do
           expect do
             dsl_compiler.attribute(attribute_name)
-          end.to raise_error(/type for attribute/)
+          end.to raise_error(/Type for attribute with name: name could not be determined/)
         end
 
         it 'creates an attribute given a name and type' do
@@ -66,16 +66,6 @@ describe Attributor::DSLCompiler do
           it 'accepts explicit nil type' do
             dsl_compiler.attribute(attribute_name, nil, **attribute_options)
           end
-
-          context 'but with the attribute also specifying a reference' do
-            let(:attribute_options) { { reference: Attributor::CSV } }
-            let(:expected_type) { Attributor::CSV }
-            let(:expected_options) { attribute_options }
-            it 'attribute reference takes precedence over the compiler one (and merges no options)' do
-              expect(attribute_options[:reference]).to_not eq(dsl_compiler_options[:reference])
-              dsl_compiler.attribute(attribute_name, **attribute_options)
-            end
-          end
         end
 
         context 'for a referenced Model attribute' do
@@ -104,22 +94,233 @@ describe Attributor::DSLCompiler do
         end
       end
 
-      context 'with a reference' do
+      context 'with a reference that contains the same name attribute' do
+        before { expect(dsl_compiler_options[:reference].attributes).to have_key(attribute_name) }
         let(:dsl_compiler_options) { { reference: Turducken } }
         let(:expected_options) do
-          attribute_options.merge(reference: reference_type)
+          reference_attribute_options.merge(attribute_options).merge(reference: reference_type)
         end
 
-        it 'sets the type of the attribute to Struct' do
+        it 'fails, since the inherited type is a fully defined struct, which cannot be redefined by a block' do
+          expect{dsl_compiler.attribute(attribute_name, **attribute_options, &attribute_block)}.to raise_error(/Invalid redefinition of attributes for an already existing type/)
+        end
+      end
+
+      context 'with a reference that does NOT contains the same name attribute' do
+        before { expect(dsl_compiler_options[:reference].attributes).to_not have_key(attribute_name) }
+        let(:dsl_compiler_options) { { reference: Person } }
+        let(:expected_options) { attribute_options }
+        
+        it 'sets the type of the attribute to Struct (and doe NOT the options from the named ref attribute)' do
           expect(Attributor::Attribute).to receive(:new)
-            .with(expected_type, description: 'The turkey', reference: Turkey)
+            .with(expected_type, expected_options)
           dsl_compiler.attribute(attribute_name, **attribute_options, &attribute_block)
         end
 
-        it 'passes the correct reference to the created attribute' do
+        it 'same as above, picks Struct and just brings in the attr options' do
           expect(Attributor::Attribute).to receive(:new).with(expected_type, expected_options)
           dsl_compiler.attribute(attribute_name, type, **attribute_options, &attribute_block)
         end
+      end
+    end
+  end
+  context 'type resolution, option inheritance for attributes with and without references' do
+    # Overall strategy
+    # 1) When no type is specified:
+    #   1.1) if it is a leaf (no block)
+    #     1.1.1) with an reference with an attr with the same name
+    #          - type copied from reference
+    #          - reference options are inherited as well (and can be overridden by local attribute ones)
+    #     1.1.2) without a ref (or the ref does not have same attribute name)
+    #          - Fail. Cannot determine type
+    #   1.2) if it has a block
+    #     1.2.1) with an reference with an attr with the same name
+    #          - Fail, as the reference would be a full type, and we cannot merge it with the block
+    #     1.2.2) without a ref (or the ref does not have same attribute name)
+    #          - defaulted to Struct (if you meant Collection.of(Struct) things would fail later somehow)
+    #          - options are NOT inherited at all (This is something we should ponder more about)
+    # 2) When type is specified:
+    #   2.1) if it is a leaf (no block)
+    #     - ignore ref if there is one (with or without matching attribute name).
+    #     - simply use provided type, and provided options (no inheritance)
+    #   2.2) if it has a block
+    #     - Same as above: use type and options provided, ignore ref if there is one (with or without matching attribute name).
+
+    let(:mytype) do 
+      Class.new(Attributor::Struct, &myblock)
+    end
+    context 'with no explicit type specified' do
+      context 'without a block (if it is a leaf)' do
+        context 'that has a reference with an attribute with the same name' do
+          let(:myblock) { 
+            Proc.new do
+              attributes reference: Duck do
+                attribute :age, required: true, min: 42
+              end
+            end
+          }
+          it 'uses type from reference' do
+            expect(mytype.attributes).to have_key(:age)
+            expect(mytype.attributes[:age].type).to eq(Duck.attributes[:age].type)
+          end
+          it 'copies over reference options and allows the attribute to override/add some' do
+            merged_options = Duck.attributes[:age].options.merge(required: true, min: 42)
+            expect(mytype.attributes[:age].options).to include(merged_options)
+          end
+        end
+        context 'with a reference, but that does not have a matching attribute name' do
+          let(:myblock) { 
+            Proc.new do
+              attributes reference: Cormorant do
+                attribute :age
+              end
+            end
+          }
+          it 'fails resolving' do
+            expect{mytype.attributes}.to raise_error(/Type for attribute with name: age could not be determined./)
+          end
+        end
+        context 'without a reference' do
+          let(:myblock) { 
+            Proc.new do
+              attributes do
+                attribute :age
+              end
+            end
+          }
+          it 'fails resolving' do
+            expect{mytype.attributes}.to raise_error(/Type for attribute with name: age could not be determined./)
+          end
+        end
+      end
+      context 'with block (if it is NOT a leaf)' do
+        context 'that has a reference with an attribute with the same name' do
+          let(:myblock) { 
+            Proc.new do
+              attributes reference: Duck do
+                attribute :age do
+                  attribute :foobar, Integer
+                end
+              end
+            end
+          }
+          it 'fails resolving' do
+            expect{mytype.attributes}.to raise_error(/Invalid redefinition of attributes for an already existing type/)
+          end
+          # context 'in the unlikely case that the reference type has an anonymous Struct (or collection of)' do
+          #   let(:myblock) { 
+          #     Proc.new do
+          #       attributes reference: PersonBlueprint do
+          #         attribute :funny_attribute, description: 'Funny business' do
+          #           attribute :foobar, Integer, min: 42
+          #         end
+          #       end
+          #     end
+          #   }
+          #   it 'correctly inherits it (same result as defaulting to Struct) and brings in the options' do
+          #     expect(mytype.attributes).to have_key(:funny_attribute)
+          #     # Resolves to Struct, and brings (and merges) the ref options with the attribute's
+          #     expect(mytype.attributes[:funny_attribute].type).to be < Attributor::Struct
+          #     merged_options = PersonBlueprint.attributes[:funny_attribute].options.merge(description: 'Funny business')
+          #     expect(mytype.attributes[:funny_attribute].options).to include(merged_options)
+          #     # And the nested attribute is correctly resolved as well, and ensures options are there
+          #     expect(mytype.attributes[:funny_attribute].type.attributes[:foobar].type).to eq(Attributor::Integer)
+          #     expect(mytype.attributes[:funny_attribute].type.attributes[:foobar].options).to eq(min: 42)
+          #   end
+          # end
+        end
+        context 'with a reference, but that does not have a matching attribute name' do
+          let(:myblock) { 
+            Proc.new do
+              attributes reference: Cormorant do
+                attribute :age, description: 'I am redefining' do
+                  attribute :foobar, Integer, min: 42
+                end
+              end
+            end
+          }
+          it 'correctly defaults to Struct uses only the local options (same exact as if it had no reference)' do
+            expect(mytype.attributes).to have_key(:age)
+            age_attribute = mytype.attributes[:age]
+            # Resolves to Struct
+            expect(age_attribute.type).to be < Attributor::Struct
+            # does NOT brings any ref options 
+            expect(age_attribute.options).to  eq(description: 'I am redefining')
+            # And the nested attribute is correctly resolved as well, and ensures options are there
+            expect(age_attribute.type.attributes[:foobar].type).to eq(Attributor::Integer)
+            expect(age_attribute.type.attributes[:foobar].options).to eq(min: 42)
+          end
+        end
+        context 'without a reference' do
+          let(:myblock) { 
+            Proc.new do
+              attributes do
+                attribute :age, description: 'I am redefining' do
+                  attribute :foobar, Integer, min: 42
+                end
+              end
+            end
+          }
+          it 'correctly defaults to Struct uses only the local options' do
+            expect(mytype.attributes).to have_key(:age)
+            age_attribute = mytype.attributes[:age]
+            # Resolves to Struct
+            expect(age_attribute.type).to be < Attributor::Struct
+            # does NOT brings any ref options 
+            expect(age_attribute.options).to  eq(description: 'I am redefining')
+            # And the nested attribute is correctly resolved as well, and ensures options are there
+            expect(age_attribute.type.attributes[:foobar].type).to eq(Attributor::Integer)
+            expect(age_attribute.type.attributes[:foobar].options).to eq(min: 42)
+          end
+        end
+      end
+    end
+    context 'with an explicit type specified' do
+      context 'without a reference' do
+        let(:myblock) { 
+          Proc.new do
+            attributes do
+              attribute :age, String, description: 'I am a String now'
+            end
+          end
+        }
+        it 'always uses the provided type and local options specified' do
+          expect(mytype.attributes).to have_key(:age)
+          age_attribute = mytype.attributes[:age]
+          # Resolves to String
+          expect(age_attribute.type).to eq(Attributor::String)
+          # copies local options
+          expect(age_attribute.options).to  eq(description: 'I am a String now')
+        end
+      end
+      context 'with a reference' do
+        let(:myblock) { 
+          Proc.new do
+            attributes reference: Duck do
+              attribute :age, String, description: 'I am a String now'
+            end
+          end
+        }
+        it 'always uses the provided type and local options specified (same as if it had no reference)' do
+          expect(mytype.attributes).to have_key(:age)
+          age_attribute = mytype.attributes[:age]
+          # Resolves to String
+          expect(age_attribute.type).to eq(Attributor::String)
+          # copies local options
+          expect(age_attribute.options).to  eq(description: 'I am a String now')
+        end
+      end
+      context 'always uses the type and options specified ignoring any reference if there is one' do
+      end
+    end
+    context 'no reference no type for leaf => error' do
+      let(:myblock) { Proc.new do
+        attributes do
+          attribute :name
+        end
+      end }
+      it 'works' do
+        expect{mytype.attributes}.to raise_error(/Type for attribute with name: name could not be determined./)
       end
     end
   end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -79,6 +79,11 @@ class Address < Attributor::Model
     attribute :name, String, example: /\w+/, null: true
     attribute :state, String, values: %w(OR CA), null: false
     attribute :person, Person, example: proc { |address, context| Person.example(context, address: address) }
+    attribute :substruct, reference: Address, null: false do
+      attribute :state, Struct do # redefine state as a Struct
+        attribute :foo, Integer, default: 1
+      end
+    end
     requires :name
   end
 end

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -175,4 +175,16 @@ describe Attributor::Type do
       end
     end
   end
+
+  context 'collection sugar' do
+    [:BigDecimal, :Boolean, :Class, :DateTime, :Date, :FileUpload, :Float, :Hash, :Integer, 
+      :Model, :Object, :Regexp, :String, :Struct, :Symbol, :Tempfile, :Time, :URI].each do |type|
+      it "DSL is equivalent to Attributor::Collection.of(#{type})" do
+        collection = Attributor.const_get(type)[]
+        expect(collection).to be < Attributor::Collection
+        expect(collection.member_type).to be Attributor.const_get(type)
+      end
+      
+    end
+  end
 end

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -177,14 +177,33 @@ describe Attributor::Type do
   end
 
   context 'collection sugar' do
-    [:BigDecimal, :Boolean, :Class, :DateTime, :Date, :FileUpload, :Float, :Hash, :Integer, 
-      :Model, :Object, :Regexp, :String, :Struct, :Symbol, :Tempfile, :Time, :URI].each do |type|
-      it "DSL is equivalent to Attributor::Collection.of(#{type})" do
-        collection = Attributor.const_get(type)[]
-        expect(collection).to be < Attributor::Collection
-        expect(collection.member_type).to be Attributor.const_get(type)
+    context 'non-constructable types' do
+      [:BigDecimal, :Boolean, :Class, :DateTime, :Date, :Float, :Integer, 
+        :Object, :Regexp, :String,  :Symbol, :Tempfile, :Time, :URI]
+        .map{|sym| Attributor.const_get(sym)}
+        .each do |type|
+        before { expect(type.constructable?).to be(false) }
+        it "DSL is equivalent to Attributor::Collection.of(#{type})" do
+          collection = type[]
+          expect(collection).to be < Attributor::Collection
+          expect(collection.member_type).to be type
+        end
+        it "caches the collection type for #{type}" do
+          expect(type[]).to be(type[])
+        end
       end
-      
+    end
+    context 'constructable types' do
+      [:Hash, :Model, :Struct, :FileUpload]
+        .map{|sym| Attributor.const_get(sym)}
+        .each do |type|
+        before { expect(type.constructable?).to be(true) }
+        it "DSL is equivalent to Attributor::Collection.of(#{type})" do
+          collection = type[]
+          expect(collection).to be < Attributor::Collection
+          expect(collection.member_type).to be type
+        end
+      end
     end
   end
 end

--- a/spec/types/model_spec.rb
+++ b/spec/types/model_spec.rb
@@ -4,7 +4,30 @@ describe Attributor::Model do
   subject(:chicken) { Chicken }
 
   # TODO: should move most of these specs to hash spec
+  context 'josep' do
+    it 'works' do      
+      aa = Address.attributes
+      # Substruct is a Struct with reference Address
+      expect(aa[:substruct].options).to include(:reference=>Address, null: false)
+      expect(aa[:substruct].type).to be <Attributor::Struct
+      expect(aa[:substruct].attributes.keys).to match([:state])
+      
+      state_attribute = aa[:substruct].attributes[:state]
+      # We expec the system to have percolated the inherited reference from Address.state ... but it won't be used
+      # as we're overriding it with a new Struct
+      expect(state_attribute.options).to include(:reference=>Attributor::String)
+      # We want to make sure no other options are set since we're starting a new structure from scratch (so it wouldn't
+      # major sense to inherit any other options? ) TODO: If the original one was a Struct...maybe it would make sense?
+      expect(state_attribute.options.keys).to_not include(:default, :values)
+      expect(state_attribute.type).to be < Attributor::Struct
 
+      # Foo gets its proper integer attribute as a leaf, and properly gets the default option as well
+      foo_attribute = state_attribute.attributes[:foo]
+      expect(foo_attribute.options).to include(default: 1)
+      expect(foo_attribute.attributes).to be_nil
+      expect(foo_attribute.type).to eq Attributor::Integer
+    end
+  end
   context 'attributes' do
     context 'with an exception from the definition block' do
       subject(:broken_model) do
@@ -140,6 +163,18 @@ describe Attributor::Model do
         subject(:attributes) { Chicken.attributes }
         it { should have_key :age }
         it { should have_key :email }
+      end
+
+      context 'other' do
+        subject(:attributes) { Address.attributes }
+        it 'works' do
+          expect(subject).to have_key(:substruct)
+          expect(subject[:substruct].type).to be < Attributor::Struct
+          expect(subject[:substruct].attributes).to have_key(:state)
+          expect(subject[:substruct].attributes[:state].type).to be < Attributor::Struct
+          expect(subject[:substruct].attributes[:state].attributes).to have_key(:foo)
+          expect(subject[:substruct].attributes[:state].attributes[:foo].type).to eq Attributor::Integer
+        end
       end
     end
 
@@ -381,7 +416,11 @@ describe Attributor::Model do
     context 'for models with circular sub-attributes' do
       context 'that are valid' do
         subject(:person) { Person.example }
-        its(:validate) { should be_empty }
+        its(:validate) { 
+          # require 'pry'
+          # binding.pry
+          should be_empty 
+        }
       end
 
       context 'that are both invalid' do
@@ -473,7 +512,7 @@ describe Attributor::Model do
     context 'for collections of models' do
       let(:attributes_block) do
         proc do
-          attribute :neighbors, required: true do
+          attribute :neighbors, Attributor::Collection.of(Attributor::Struct), required: true do
             attribute :name, required: true
             attribute :age, Integer
           end
@@ -482,10 +521,11 @@ describe Attributor::Model do
       subject(:struct) { Attributor::Struct.construct(attributes_block, reference: Cormorant) }
 
       it 'supports defining sub-attributes using the proper reference' do
+        # in construct, we're passing the reference, so it will use it to define the inner name/age attributes
         expect(struct.attributes[:neighbors].options[:required]).to be true
-        expect(struct.attributes[:neighbors].options[:null]).to be false
+        expect(struct.attributes[:neighbors].options).to_not have_key(:null) # Not inherited from reference
+        
         expect(struct.attributes[:neighbors].type.member_attribute.type.attributes.keys).to match_array [:name, :age]
-
         name_options = struct.attributes[:neighbors].type.member_attribute.type.attributes[:name].options
         expect(name_options[:required]).to be true
         expect(name_options[:description]).to eq 'Name of the Cormorant'


### PR DESCRIPTION
- Support for defining collections of types using a more terse DSL: T[]
  - For example: Attributor::Integer[] is equivalent to Attributor::Collection.of(Attributor::Integer)
  - It also caches these collection types when they are concrete (i.e., not constructable like Struct[], etc...)
- Revamped the type and options inheritance (and :reference behavior) when defining attributes:
  - The matrix of behavior is now fully defined, and all possible combinations of parameters are tested
  - tightened up some error cases and messaging (i.e., cannot pass :reference unless there is a block, etc...)