### PR TITLE
Load custom_option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Attributor Changelog
 
 ## next
+- Enhance custom_option handling. The values provided for custom options are now loaded (and definition will fail if they aren't compatible). This was specially
+  important for custom options that were collections, etc.
 
 ## 7.0 (5/23/2023)
 - Support for loading "<digits>." strings in BigDecimal/Float types (These are formats supported by JS, Java ..)

--- a/lib/attributor/attribute.rb
+++ b/lib/attributor/attribute.rb
@@ -42,6 +42,17 @@ module Attributor
       @type = Attributor.resolve_type(type, options, block)
       @options = @type.respond_to?(:options) ?  @type.options.merge(options) : options
 
+      # We will give the values passed for options, a chance to be 'loaded' by its type, so we store native loaded values in the options
+      begin
+        current_option_name = nil # Use this to avoid having to wrap each loop with a begin/rescue block
+        (self.class.custom_options.keys & @options.keys).each do |custom_key|
+          current_option_name = custom_key
+          @options[custom_key] = self.class.custom_options[custom_key].load(@options[custom_key]) 
+        end
+      rescue => e
+        raise AttributorException,  "Error while loading value #{@options[current_option_name]} for custom option '#{current_option_name}': #{e.message}"
+      end
+
       check_options!
     end
 

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -232,6 +232,16 @@ describe Attributor::Attribute do
         end
       end
 
+      context 'validates the type of values' do 
+        let(:custom_option_args) { [option_name, String ] }
+        
+        it 'raises with an invalid option value' do
+          expect do
+            Attributor::Attribute.new(Integer, foo: {a:1})
+          end.to raise_error(Attributor::AttributorException,/Error while loading value {:a=>1} for custom option 'foo': Type Attributor::String cannot load values of type Hash/)
+        end
+      end
+
       it 'appear in as_json_schema' do
         attribute = Attributor::Attribute.new(Integer, foo: 'valid')
         json_schema = attribute.as_json_schema


### PR DESCRIPTION
load 'values' of custom options on attribute initialization (so we have them in the right type, and/or we fail loudly if they're incompatible)