### PR TITLE
polymorphic type support for docs

### DIFF
--- a/lib/attributor/types/polymorphic.rb
+++ b/lib/attributor/types/polymorphic.rb
@@ -115,5 +115,26 @@ module Attributor
         description[key] = { type: value.describe(true) }
       end
     end
+
+    def self.json_schema_type
+      :object
+    end
+
+    def self.as_json_schema(**opts)
+      base_schema = super(**opts)
+
+      {
+        **base_schema,
+        oneOf: types.map do |type_name, type_class|
+          schema = type_class.as_json_schema
+          schema[:title] = type_name
+          schema
+        end,
+        discriminator: {
+          propertyName: discriminator,
+          mapping: types.transform_values { |type_class| type_class.json_schema_type }
+        }
+      }
+    end
   end
 end

--- a/spec/types/polymorphic_spec.rb
+++ b/spec/types/polymorphic_spec.rb
@@ -131,4 +131,25 @@ describe Attributor::Polymorphic do
       end
     end
   end
+
+  context '.as_json_schema' do
+    let(:json_schema) { type.as_json_schema }
+
+    it 'includes oneOf with the correct type schemas' do
+      expect(json_schema[:oneOf].map { |s| s[:title].to_s }).to match_array(%w[chicken duck turkey])
+    end
+
+    it 'includes a discriminator with the correct propertyName' do
+      expect(json_schema[:discriminator][:propertyName]).to eq(:type)
+    end
+
+    it 'includes a mapping for the types' do
+      expected_mapping = {
+        chicken: Chicken.json_schema_type,
+        duck: Duck.json_schema_type,
+        turkey: Turkey.json_schema_type
+      }
+      expect(json_schema[:discriminator][:mapping]).to eq(expected_mapping)
+    end
+  end
 end


### PR DESCRIPTION
make polymorphic types show up in the docs as "one of", with the select switching between the type attributes and what not. haven't had time to write tests but, screenshot that it's working below. also integration tested fetching and creating and what not. - works nested in polymorphic as well.

<img width="526" alt="Screen Shot 2024-09-30 at 3 48 05 PM" src="https://github.com/user-attachments/assets/bb67aef8-d1a4-4b09-8938-2e4b9ccf9fcc">

would love more documentation for attributor btw :) - I went down a bunch of different failed rabbit holes initially because I missed how to do some pretty basic attributor stuff (and the whole polymorphics.rb file in spec/support, which made me realize I could declare things inline and generic types as models)