### PR TITLE
Loosen hashie version constraint to allow 4.x and 5.x

### DIFF
--- a/attributor.gemspec
+++ b/attributor.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
 
-  spec.add_runtime_dependency('hashie', ['~> 3'])
-  spec.add_runtime_dependency('faker', [' >= 3.2'])
+  spec.add_runtime_dependency('hashie', ['>= 3'])
+  spec.add_runtime_dependency('faker', ['>= 3.2'])
   spec.add_runtime_dependency('activesupport', ['>= 3'])
 
   spec.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
  ## Summary

  - Changes `hashie` dependency from `~> 3` (capped at `< 4`) to `>= 3`, allowing hashie 4.x and 5.x
  - Fixes a stray leading space in the `faker` constraint string
